### PR TITLE
Add autospacing around italics in Markdown rendering.

### DIFF
--- a/claat/render/md.go
+++ b/claat/render/md.go
@@ -128,7 +128,7 @@ func (mw *mdWriter) text(n *types.TextNode) {
 		mw.writeString("__")
 	}
 	if n.Italic {
-		mw.writeString("*")
+		mw.writeString(" *")
 	}
 	if n.Code {
 		mw.writeString("`")
@@ -138,7 +138,7 @@ func (mw *mdWriter) text(n *types.TextNode) {
 		mw.writeString("`")
 	}
 	if n.Italic {
-		mw.writeString("*")
+		mw.writeString("* ")
 	}
 	if n.Bold {
 		mw.writeString("__")


### PR DESCRIPTION
This should stop the output from jamming subsequent Markdown parsing performed on the output. I suspect that the risk of accidental double spaces isn't a big problem, as once parsed as breaking spaces to HTML, they'll be consolidated into one.

If we should fight double spacing, I can trivially add a lookback mechanism similar to lineStart, but a lookahead mechanism would be a bit more architecturally complex. WDYT?