### PR TITLE
claat/parser,claat/types: add Author meta field

### DIFF
--- a/claat/parser/gdoc/parse.go
+++ b/claat/parser/gdoc/parse.go
@@ -379,6 +379,8 @@ func metaTable(ds *docState) {
 		switch strings.ToLower(stringifyNode(tr.FirstChild, true)) {
 		case "id", "url":
 			ds.clab.ID = s
+		case "author":
+			ds.clab.Author = s
 		case "summary":
 			ds.clab.Summary = s
 		case "category", "categories":

--- a/claat/parser/gdoc/parse_test.go
+++ b/claat/parser/gdoc/parse_test.go
@@ -135,6 +135,70 @@ func TestParseTopCodeBlock(t *testing.T) {
 	}
 }
 
+func TestMetaTable(t *testing.T) {
+	const markup = `
+	<html>
+	<body>
+		<table>
+			<tr>
+				<td>Summary</td>
+				<td>Test summary</td>
+			</tr>
+			<tr>
+				<td>Author</td>
+				<td>John Smith &lt;user@example.com&gt;</td>
+			</tr>
+			<tr>
+				<td>Category</td>
+				<td>Foo, Bar</td>
+			</tr>
+			<tr>
+				<td>Environment</td>
+				<td>Web, Kiosk</td>
+			</tr>
+			<tr>
+				<td>Status</td>
+				<td>Final</td>
+			</tr>
+			<tr>
+				<td>Feedback</td>
+				<td>https://example.com/issues</td>
+			</tr>
+			<tr>
+				<td>Analytics</td>
+				<td>GA-12345</td>
+			</tr>
+		</table>
+	</body>
+	</html>
+	`
+
+	p := &Parser{}
+	clab, err := p.Parse(markupReader(markup))
+	if err != nil {
+		t.Fatal(err)
+	}
+	meta := types.Meta{
+		Summary:    "Test summary",
+		Author:     "John Smith <user@example.com>",
+		Categories: []string{"Foo", "Bar"},
+		Theme:      "foo",
+		Status:     clab.Meta.Status, // verified separately
+		Feedback:   "https://example.com/issues",
+		GA:         "GA-12345",
+		// Tags are always sorted.
+		// TODO: move sorting to Parse of the parser package
+		Tags: []string{"kiosk", "web"},
+	}
+	if !reflect.DeepEqual(clab.Meta, meta) {
+		t.Errorf("Meta: \n%+v\nwant:\n%+v", clab.Meta, meta)
+	}
+	status := types.LegacyStatus([]string{"final"})
+	if !reflect.DeepEqual(clab.Meta.Status, &status) {
+		t.Errorf("Meta.Status: %q; want %q", clab.Meta.Status, &status)
+	}
+}
+
 func TestParseDoc(t *testing.T) {
 	const markup = `
 	<html><head><style>

--- a/claat/parser/md/parse.go
+++ b/claat/parser/md/parse.go
@@ -36,6 +36,7 @@ import (
 )
 
 const (
+	metaAuthor           = "author"
 	metaSummary          = "summary"
 	metaID               = "id"
 	metaCategories       = "categories"
@@ -172,8 +173,10 @@ func parseMarkup(markup io.Reader) (*types.Codelab, error) {
 	return ps.c, nil
 }
 
-// parseMetadata handles the metadata section preceding a codelab. It assumes the tokenizer is pointing to the first <p>/
-// It returns any errors it encounters, and leaves the tokenizer pointing at the <h1> starting the codelab title, or at io.EOF.
+// parseMetadata handles the metadata section preceding a codelab.
+// It assumes the tokenizer is pointing to the first <p>/.
+// It returns any errors it encounters, and leaves the tokenizer pointing at the <h1>
+// starting the codelab title, or at io.EOF.
 func parseMetadata(ps *parserState) error {
 	m := map[string]string{}
 	// Iterate over the metadata elements, constructing a map of the metadata.
@@ -477,6 +480,9 @@ func standardSplit(s string) []string {
 func addMetadataToCodelab(m map[string]string, c *types.Codelab) {
 	for k, v := range m {
 		switch k {
+		case metaAuthor:
+			// Directly assign the summary to the codelab field.
+			c.Author = v
 		case metaSummary:
 			// Directly assign the summary to the codelab field.
 			c.Summary = v

--- a/claat/parser/md/parse_test.go
+++ b/claat/parser/md/parse_test.go
@@ -177,6 +177,7 @@ func TestAddMetadataToCodelab(t *testing.T) {
 	}{
 		{
 			map[string]string{
+				"author":            "john smith",
 				"summary":           "abcdefghij",
 				"id":                "zyxwvut",
 				"categories":        "not, really",
@@ -187,6 +188,7 @@ func TestAddMetadataToCodelab(t *testing.T) {
 			},
 			types.Codelab{
 				Meta: types.Meta{
+					Author:     "john smith",
 					Summary:    "abcdefghij",
 					ID:         "zyxwvut",
 					Categories: []string{"not", "really"},
@@ -201,8 +203,8 @@ func TestAddMetadataToCodelab(t *testing.T) {
 	for i, tc := range tests {
 		out := types.Codelab{}
 		addMetadataToCodelab(tc.in, &out)
-		if !reflect.DeepEqual(tc.out, out) {
-			t.Errorf("%d: [%q] got %v, want %v", i, tc.in, out, tc.out)
+		if !reflect.DeepEqual(out, tc.out) {
+			t.Errorf("%d:\n%+v\nwant:\n%+v", i, out, tc.out)
 		}
 	}
 }

--- a/claat/types/meta.go
+++ b/claat/types/meta.go
@@ -23,12 +23,11 @@ import (
 )
 
 // Meta contains a single codelab metadata.
-// Format, Env   should not be set by a parser, as they may be overwritten
-// by the parser callers.
 type Meta struct {
 	ID         string        `json:"id"`                 // ID is also part of codelab URL
 	Duration   int           `json:"duration"`           // Codelab duration in minutes
 	Title      string        `json:"title"`              // Codelab title
+	Author     string        `json:"author,omitempty"`   // Arbitrary authorship text
 	Summary    string        `json:"summary"`            // Short summary
 	Theme      string        `json:"theme"`              // Usually first item of Categories
 	Status     *LegacyStatus `json:"status"`             // Draft, Published, Hidden, etc.


### PR DESCRIPTION
This adds a new Author field to the codelab metadata.

R: @marcacohen @chrisrecher 
Closes #13