### PR TITLE
claat: add -auth flag to command line args

### DIFF
--- a/claat/auth.go
+++ b/claat/auth.go
@@ -86,6 +86,12 @@ func driveClient() (*http.Client, error) {
 // tokenSource creates a new oauth2.TokenSource backed by tokenRefresher,
 // using previously stored user credentials if available.
 func tokenSource(provider string) (oauth2.TokenSource, error) {
+	// Ignore provider if *authToken is given.
+	if *authToken != "" {
+		tok := &oauth2.Token{AccessToken: *authToken}
+		return oauth2.StaticTokenSource(tok), nil
+	}
+
 	conf := authConfig[provider]
 	if conf == nil {
 		return nil, fmt.Errorf("no auth config for %q", provider)

--- a/claat/auth_test.go
+++ b/claat/auth_test.go
@@ -1,0 +1,33 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "testing"
+
+func TestAuthTokenArg(t *testing.T) {
+	const token = "test-token"
+	*authToken = token
+	src, err := tokenSource("ignored")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tok, err := src.Token()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tok.AccessToken != token {
+		t.Errorf("tok.AccessToken = %q; want %q", tok.AccessToken, token)
+	}
+}

--- a/claat/main.go
+++ b/claat/main.go
@@ -30,12 +30,13 @@ import (
 )
 
 var (
-	output   = flag.String("o", ".", "output directory or '-' for stdout")
-	expenv   = flag.String("e", "web", "codelab environment")
-	tmplout  = flag.String("f", "html", "output format")
-	prefix   = flag.String("prefix", "../../", "URL prefix for html format")
-	globalGA = flag.String("ga", "UA-49880327-14", "global Google Analytics account")
-	extra    = flag.String("extra", "", "Additional arguments to pass to format templates. JSON object of string,string key values.")
+	authToken = flag.String("auth", "", "OAuth2 Bearer token; alternative credentials override.")
+	output    = flag.String("o", ".", "output directory or '-' for stdout")
+	expenv    = flag.String("e", "web", "codelab environment")
+	tmplout   = flag.String("f", "html", "output format")
+	prefix    = flag.String("prefix", "../../", "URL prefix for html format")
+	globalGA  = flag.String("ga", "UA-49880327-14", "global Google Analytics account")
+	extra     = flag.String("extra", "", "Additional arguments to pass to format templates. JSON object of string,string key values.")
 
 	version string // set by linker -X
 )


### PR DESCRIPTION
The new command line flag overrides regular claat credentials.
Closes #16 

R: @marcacohen @hostirosti 