### PR TITLE
Ensure we detect all codelabs step with md parser

### DIFF
--- a/claat/parser/md/parse.go
+++ b/claat/parser/md/parse.go
@@ -160,6 +160,10 @@ func parseMarkup(markup io.Reader) (*types.Codelab, error) {
 			// If we just finished parsing a step or the title, we are left possibly pointing to the opening
 			// <h2> of another step. Update the flag accordingly.
 			inStepTitle = (ps.t.Type == html.StartTagToken && ps.t.DataAtom == atom.H2)
+		} else {
+			// If we had some intermediate blank lines between step, and are out of one, check if we don't reenter
+			// into a new step.
+			inStepTitle = (ps.t.Type == html.StartTagToken && ps.t.DataAtom == atom.H2)
 		}
 
 	}


### PR DESCRIPTION
The following structure:
 # Page title

 ## First Step
 Duration: 0:01

Will render this intermediate html output with blackfriday:
<h1>Page title</h1>

<h2>First Step</h2>

<p>Duration: 0:01</p>

The issue is the call to .advance() on the token, while treating h1, will then
be an empty string. Consequence is that inStepTitle is thus false and will
never have the opportunity to become true again (same with two steps separated
by a blank line).

The fix ensure that we can detect and reenter a new step, even if we went out
of any of them.