### PR TITLE
Standardize the tags and append to the codelab field

### DIFF
--- a/claat/parser/md/parse.go
+++ b/claat/parser/md/parse.go
@@ -43,6 +43,7 @@ const (
 	metaStatus           = "status"
 	metaFeedbackLink     = "feedback link"
 	metaAnalyticsAccount = "analytics account"
+	metaTags             = "tags"
 )
 
 var metadataRegexp = regexp.MustCompile(`(.+?):(.+)`)
@@ -506,6 +507,10 @@ func addMetadataToCodelab(m map[string]string, c *types.Codelab) {
 		case metaAnalyticsAccount:
 			// Directly assign the GA id to the codelab field.
 			c.GA = v
+			break
+		case metaTags:
+			// Standardize the tags and append to the codelab field.
+			c.Tags = append(c.Tags, standardSplit(v)...)
 			break
 		default:
 			break


### PR DESCRIPTION
Mirroring the gdoc where tags are coming from both Environments
and Tags, support the same independant tags for Markdown parser.