### PR TITLE
claat: enable support for Team Drive

### DIFF
--- a/claat/fetch.go
+++ b/claat/fetch.go
@@ -197,7 +197,11 @@ func fetchDriveFile(id string, nometa bool) (*resource, error) {
 		return &resource{body: res.Body, typ: srcGoogleDoc}, nil
 	}
 
-	u := fmt.Sprintf("%s/files/%s?fields=id,mimeType,modifiedTime", driveAPI, id)
+	q := url.Values{
+		"fields":             {"id,mimeType,modifiedTime"},
+		"supportsTeamDrives": {"true"},
+	}
+	u := fmt.Sprintf("%s/files/%s?%s", driveAPI, id, q.Encode())
 	res, err := retryGet(client, u, 7)
 	if err != nil {
 		return nil, err

--- a/claat/fetch_test.go
+++ b/claat/fetch_test.go
@@ -72,6 +72,9 @@ func TestFetchRemoteDrive(t *testing.T) {
 		}
 		// metadata request
 		if strings.HasSuffix(r.URL.Path, "/files/doc-123") {
+			if v := r.FormValue("supportsTeamDrives"); v != "true" {
+				t.Errorf("supportsTeamDrives = %q; want 'true'", v)
+			}
 			b := ioutil.NopCloser(strings.NewReader(`{
 				"mimeType": "application/vnd.google-apps.document"
 			}`))


### PR DESCRIPTION
We don't do anything specific, just fetching a couple metadata fields.
So, this seems to be as simple as opting-in as described in
https://developers.google.com/drive/v3/web/enable-teamdrives

Closes #34.