### PR TITLE
ci: switch Go version to latest release; lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 sudo: false
+git:
+  depth: 3
 language: go
 go:
-- 1.8.x # need for App Engine
-- master
+- 1.8.x  # need for App Engine
+- 1.10.x # latest release because "master" is dev version
 install:
 - go get github.com/golang/lint/golint
 - go get -t -d ./claat/...
@@ -18,7 +20,7 @@ deploy:
   on:
     repo: googlecodelabs/tools
     tags: true
-    go: master
+    go: 1.10.x # match the above; latest release
   skip_cleanup: true
   file:
   - claat/bin/claat-darwin-amd64

--- a/claat/export.go
+++ b/claat/export.go
@@ -45,7 +45,7 @@ func cmdExport() {
 			ch <- &result{src, meta, err}
 		}(src)
 	}
-	for _ = range args {
+	for range args {
 		res := <-ch
 		if res.err != nil {
 			errorf(reportErr, res.src, res.err)

--- a/claat/fetch.go
+++ b/claat/fetch.go
@@ -97,7 +97,7 @@ func slurpCodelab(src string) (*codelab, error) {
 			ch <- nil
 		}(imp)
 	}
-	for _ = range imports {
+	for range imports {
 		if err := <-ch; err != nil {
 			return nil, err
 		}

--- a/claat/parser/gdoc/parse_test.go
+++ b/claat/parser/gdoc/parse_test.go
@@ -194,8 +194,11 @@ func TestMetaTable(t *testing.T) {
 		t.Errorf("Meta: \n%+v\nwant:\n%+v", clab.Meta, meta)
 	}
 	status := types.LegacyStatus([]string{"final"})
+	if clab.Meta.Status == nil {
+		t.Fatalf("Meta.Status is nil; want %q", status)
+	}
 	if !reflect.DeepEqual(clab.Meta.Status, &status) {
-		t.Errorf("Meta.Status: %q; want %q", clab.Meta.Status, &status)
+		t.Errorf("Meta.Status: %q; want %q", *clab.Meta.Status, status)
 	}
 }
 

--- a/claat/update.go
+++ b/claat/update.go
@@ -58,7 +58,7 @@ func cmdUpdate() {
 			ch <- &result{d, meta, err}
 		}(d)
 	}
-	for _ = range dirs {
+	for range dirs {
 		res := <-ch
 		if res.err != nil {
 			errorf(reportErr, res.dir, res.err)
@@ -154,7 +154,7 @@ func scanPaths(roots []string) ([]string, error) {
 		}(r)
 	}
 	var dirs []string
-	for _ = range roots {
+	for range roots {
 		res := <-ch
 		if res.err != nil {
 			return nil, fmt.Errorf("%s: %v", res.root, res.err)


### PR DESCRIPTION
Previously, we used "master" version of Go on Travis CI.
Apparently, this uses a tip version and not the latest release.

So, use a fixed version.
The downside is we'll need to update it with each new Go release,
but it's still better than building release binaries using
a tip version.

Once submitted, https://github.com/googlecodelabs/tools/pull/33#issuecomment-398311679 can be rebased to make that PR green.

R: @didrocks @samtstern