### PR TITLE
Support MD exporting from the network

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_Store
 .drone.sec.yml
+.idea/
+debug.test

--- a/claat/export.go
+++ b/claat/export.go
@@ -191,7 +191,7 @@ func slurpImages(client *http.Client, src, dir string, steps []*types.Step) (map
 		for _, n := range nodes {
 			go func(n *types.ImageNode) {
 				url := n.Src
-				file, err := slurpBytes(client, src, dir, url, 5)
+				file, err := slurpBytes(client, src, dir, url)
 				if err == nil {
 					n.Src = filepath.Join(imgDirname, file)
 				}


### PR DESCRIPTION
Fixes #60

Tested with this:
```
claat export https://raw.githubusercontent.com/firebase/friendlyeats-android/master/docs/codelab.md
```

Also confirmed that changing the image-getting logic does not affect the `gdoc` export flow.