### PR TITLE
Markdown bash rendering fix

### DIFF
--- a/claat/render/md.go
+++ b/claat/render/md.go
@@ -183,18 +183,7 @@ func (mw *mdWriter) code(n *types.CodeNode) {
 	mw.newBlock()
 	defer mw.writeBytes(newLine)
 	if n.Term {
-		var buf bytes.Buffer
-		const prefix = "    "
-		lineStart := true
-		for _, r := range n.Value {
-			if lineStart {
-				buf.WriteString(prefix)
-			}
-			buf.WriteRune(r)
-			lineStart = r == '\n'
-		}
-		mw.writeBytes(buf.Bytes())
-		return
+		n.Lang = "bash"
 	}
 	mw.writeString("```")
 	mw.writeString(n.Lang)


### PR DESCRIPTION
Technically, terminal snippets should use bash code block rendering. Could cause issues when tools rely on the language annotation for terminal commands.