### PR TITLE
Allow markdown export to handle image sizes

### DIFF
--- a/claat/parser/md/parse.go
+++ b/claat/parser/md/parse.go
@@ -650,6 +650,14 @@ func image(ds *docState) types.Node {
 		n.Title = title
 	}
 
+	if ws := nodeAttr(ds.cur, "width"); ws != "" {
+		w,err := strconv.ParseFloat(ws, 64)
+		if err != nil {
+			return nil
+		}
+		n.MaxWidth = float32(w)
+	}
+
 	n.MutateBlock(findBlockParent(ds.cur))
 	return n
 }

--- a/claat/render/md.go
+++ b/claat/render/md.go
@@ -148,18 +148,25 @@ func (mw *mdWriter) text(n *types.TextNode) {
 
 func (mw *mdWriter) image(n *types.ImageNode) {
 	mw.space()
-	mw.writeString("![")
+	mw.writeString("<img ")
+	mw.writeString(fmt.Sprintf("src=\"%s\" ", n.Src))
+
 	if n.Alt != "" {
-		mw.writeString(n.Alt)
+		mw.writeString(fmt.Sprintf("alt=\"%s\" ", n.Alt))
 	} else {
-		mw.writeString(path.Base(n.Src))
+		mw.writeString(fmt.Sprintf("alt=\"%s\" ", path.Base(n.Src)))
 	}
-	mw.writeString("](")
-	mw.writeString(n.Src)
+
 	if n.Title != "" {
-		mw.writeString(fmt.Sprintf(" %q", n.Title))
+		mw.writeString(fmt.Sprintf("title=\"%q\" ", n.Title))
 	}
-	mw.writeString(")")
+
+	// If available append width to the src string of the image.
+	if n.MaxWidth > 0 {
+		mw.writeString(fmt.Sprintf(" width=\"%.2f\" ", n.MaxWidth))
+	}
+
+	mw.writeString("/>")
 }
 
 func (mw *mdWriter) url(n *types.URLNode) {


### PR DESCRIPTION
Use HTML image tag since it provides easy access to width attribute.
This allows MD format to produce codelabs with images similar to
those produced from the html format.