### PR TITLE
Change export command to receive sources from opts, not args list.

### DIFF
--- a/claat/cmd/export.go
+++ b/claat/cmd/export.go
@@ -40,6 +40,8 @@ type CmdExportOptions struct {
 	Output string
 	// Prefix is a URL prefix to prepend when using HTML format.
 	Prefix string
+	// Srcs is the sources to export codelabs from.
+	Srcs []string
 	// Tmplout is the output format.
 	Tmplout string
 }
@@ -56,15 +58,15 @@ func CmdExport(opts CmdExportOptions) int {
 		meta *types.Meta
 		err  error
 	}
-	args := unique(flag.Args())
-	ch := make(chan *result, len(args))
-	for _, src := range args {
+	srcs := unique(opts.Srcs)
+	ch := make(chan *result, len(srcs))
+	for _, src := range srcs {
 		go func(src string) {
 			meta, err := exportCodelab(src, opts)
 			ch <- &result{src, meta, err}
 		}(src)
 	}
-	for range args {
+	for range srcs {
 		res := <-ch
 		if res.err != nil {
 			exitCode = 1

--- a/claat/main.go
+++ b/claat/main.go
@@ -77,6 +77,7 @@ func main() {
 			GlobalGA:  *globalGA,
 			Output:    *output,
 			Prefix:    *prefix,
+			Srcs:      flag.Args(),
 			Tmplout:   *tmplout,
 		})
 	case "serve":


### PR DESCRIPTION
I need this urgently, so I'm just changing the one command for now. I'll circle back and make the other commands not directly access flags.Args later.