### PR TITLE
fix problem with go get producing bad executable

### DIFF
--- a/claat/main.go
+++ b/claat/main.go
@@ -64,7 +64,7 @@ func main() {
 
 	useElems, err := strconv.ParseBool(useElements)
 	if err != nil {
-		os.Exit(1)
+		useElems = false
 	}
 	if useElems && *tmplout == "html"{
 		*tmplout = "htmlElements"


### PR DESCRIPTION
This if statement from main.go:

    useElems, err := strconv.ParseBool(useElements)
    if err != nil {
            os.Exit(1)
    }

requires the useElements arg be set, which happens when you run 'make' but not 'go build'. A better strategy, I think, would be to set reasonable default so that the command works as usual even when this arg is not supplied.