### PR TITLE
added language to CodeNode constructor

### DIFF
--- a/claat/parser/md/parse.go
+++ b/claat/parser/md/parse.go
@@ -590,7 +590,8 @@ func code(ds *docState, term bool) types.Node {
 	} else if ds.cur.Parent.FirstChild == ds.cur && ds.cur.Parent.DataAtom != atom.Span {
 		v = "\n" + v
 	}
-	n := types.NewCodeNode(v, term)
+	lang := nodeAttr(ds.cur, "class")
+	n := types.NewCodeNode(lang, v, term)
 	n.MutateBlock(elem)
 	return n
 }

--- a/claat/types/node.go
+++ b/claat/types/node.go
@@ -274,12 +274,14 @@ func (tn *TextNode) Empty() bool {
 }
 
 // NewCodeNode creates a new Node of type NodeCode.
+// Use l argument to specify a language.
 // Use term argument to specify a terminal output.
-func NewCodeNode(v string, term bool) *CodeNode {
+func NewCodeNode(l, v string, term bool) *CodeNode {
 	return &CodeNode{
 		node:  node{typ: NodeCode},
 		Value: v,
 		Term:  term,
+		Lang: l,
 	}
 }
 


### PR DESCRIPTION
The README for the[ parser page](https://github.com/googlecodelabs/tools/tree/master/claat/parser/md) says the following:

> Put the name of the code language after the first fence to explicitly specify which highlighting plan to use.

This feature wasn't actually implemented, as the parser wasn't setting the language field in the constructed CodeNode. This PR fixes that