### PR TITLE
Further fixes to buttons

### DIFF
--- a/codelab-elements/google-codelab-step/google_codelab_step.scss
+++ b/codelab-elements/google-codelab-step/google_codelab_step.scss
@@ -179,7 +179,12 @@ google-codelab-step .instructions strong {
   font-weight: 600;
 }
 
+google-codelab-step .instructions :link paper-button {
+  text-decoration: none !important;
+}
+
 google-codelab-step .instructions paper-button {
+  display: inline-block;
   border-radius: 4px;
   color: #FFFFFF;
   font-family: 'Google Sans', Arial, sans-serif;
@@ -214,10 +219,9 @@ google-codelab-step .instructions paper-button.red {
 }
 
 google-codelab-step .instructions iron-icon {
-  max-height: 16px;
-  max-width: 16px;
-  margin-top: 4px;
+  vertical-align: sub;
   margin-right: 7px;
+  margin-left: 3px;
   font-size: 16px;
 }
 


### PR DESCRIPTION
Removed the :link underline of buttons when they are inside an achor tag. Had to switch to display:inline-block and therefore also change the way the iron-icons are aligned in there.

Result:

![image](https://user-images.githubusercontent.com/3766663/52981419-fd2fc280-33df-11e9-9c8a-028b57ae9677.png)
