### PR TITLE
Add `build` in Available commands

### DIFF
--- a/claat/main.go
+++ b/claat/main.go
@@ -137,7 +137,7 @@ func usage() {
 
 const usageText = `Usage: claat <cmd> [options] src [src ...]
 
-Available commands are: export, serve, update, version.
+Available commands are: export, build, serve, update, version.
 
 ## Export command
 


### PR DESCRIPTION
`build` command explanation is written in `## Build command` section; however, `build`  is a lack of `Available command`.