### PR TITLE
Fixed bug: First page load event triggering too early

### DIFF
--- a/codelab-elements/google-codelab/google_codelab.js
+++ b/codelab-elements/google-codelab/google_codelab.js
@@ -249,7 +249,9 @@ class Codelab extends HTMLElement {
         break;
       case ANALYTICS_READY_ATTR:
         if (this.hasAttribute(ANALYTICS_READY_ATTR)) {
-          this.firePageLoadEvents_();
+          window.addEventListener("load", (event) => {
+            this.firePageLoadEvents_();
+          });
         }
         break;
     }

--- a/codelab-elements/google-codelab/google_codelab.js
+++ b/codelab-elements/google-codelab/google_codelab.js
@@ -265,7 +265,7 @@ class Codelab extends HTMLElement {
           if (this.ready_) {
             this.firePageLoadEvents_();
           } else {
-            document.body.addEventListener(CODELAB_READY_EVENT,
+            this.addEventListener(CODELAB_READY_EVENT,
                 () => this.firePageLoadEvents_());
           }
         }
@@ -744,9 +744,10 @@ class Codelab extends HTMLElement {
    */
   fireEvent_(eventName, detail={}) {
     const event = new CustomEvent(eventName, {
-      detail: detail
+      detail: detail,
+      bubbles: true,
     });
-    document.body.dispatchEvent(event);
+    this.dispatchEvent(event);
   }
 
   /**

--- a/codelab-elements/google-codelab/google_codelab.js
+++ b/codelab-elements/google-codelab/google_codelab.js
@@ -102,9 +102,9 @@ const CODELAB_ACTION_EVENT = 'google-codelab-action';
 const CODELAB_PAGEVIEW_EVENT = 'google-codelab-pageview';
 
 /**
- * The general codelab action event fired when the Codelab elemnt is setup.
+ * The general codelab action event fired when the codelab element is ready.
  */
-const CODELAB_SETUP_EVENT = 'google-codelab-setup'
+const CODELAB_READY_EVENT = 'google-codelab-ready'
 
 /**
  * @extends {HTMLElement}
@@ -164,6 +164,9 @@ class Codelab extends HTMLElement {
     /** @private {boolean} */
     this.hasSetup_ = false;
 
+    /** @private {boolean} */
+    this.ready_ = false;
+
     /** @private {?Transition} */
     this.transitionIn_ = null;
 
@@ -200,6 +203,11 @@ class Codelab extends HTMLElement {
     if (this.resumed_) {
       console.log('resumed');
       // TODO Show resume dialog
+    }
+
+    if (!this.ready_) {
+      this.ready_ = true;
+      this.fireEvent_(CODELAB_READY_EVENT);
     }
   }
 
@@ -254,11 +262,11 @@ class Codelab extends HTMLElement {
         break;
       case ANALYTICS_READY_ATTR:
         if (this.hasAttribute(ANALYTICS_READY_ATTR)) {
-          if (this.hasSetup_) {
+          if (this.ready_) {
             this.firePageLoadEvents_();
           } else {
-            this.addEventListener(CODELAB_SETUP_EVENT,
-                                  () => this.firePageLoadEvents_());
+            document.body.addEventListener(CODELAB_READY_EVENT,
+                () => this.firePageLoadEvents_());
           }
         }
         break;
@@ -796,7 +804,6 @@ class Codelab extends HTMLElement {
     }
 
     this.hasSetup_ = true;
-    this.fireEvent_(CODELAB_SETUP_EVENT);
   }
 }
 

--- a/codelab-elements/google-codelab/google_codelab.js
+++ b/codelab-elements/google-codelab/google_codelab.js
@@ -102,6 +102,11 @@ const CODELAB_ACTION_EVENT = 'google-codelab-action';
 const CODELAB_PAGEVIEW_EVENT = 'google-codelab-pageview';
 
 /**
+ * The general codelab action event fired when the Codelab elemnt is setup.
+ */
+const CODELAB_SETUP_EVENT = 'google-codelab-setup'
+
+/**
  * @extends {HTMLElement}
  */
 class Codelab extends HTMLElement {
@@ -249,9 +254,12 @@ class Codelab extends HTMLElement {
         break;
       case ANALYTICS_READY_ATTR:
         if (this.hasAttribute(ANALYTICS_READY_ATTR)) {
-          window.addEventListener("load", (event) => {
+          if (this.hasSetup_) {
             this.firePageLoadEvents_();
-          });
+          } else {
+            this.addEventListener(CODELAB_SETUP_EVENT,
+                                  () => this.firePageLoadEvents_());
+          }
         }
         break;
     }
@@ -788,6 +796,7 @@ class Codelab extends HTMLElement {
     }
 
     this.hasSetup_ = true;
+    this.fireEvent_(CODELAB_SETUP_EVENT);
   }
 }
 


### PR DESCRIPTION
For the first page load, the page load event was sent too early since it need some stuff to be initialised in the codelabs object. Fixed that by adding a "codelab ready" event and waiting for that to trigger first page load event.