### PR TITLE
Center images and Youtube videos.

### DIFF
--- a/claat/render/html.go
+++ b/claat/render/html.go
@@ -151,9 +151,6 @@ func (hw *htmlWriter) text(n *types.TextNode) {
 	if n.Code {
 		hw.writeString("<code>")
 	}
-	if !n.Bold && !n.Italic && !n.Code {
-		hw.writeString("<span>")
-	}
 	s := htmlTemplate.HTMLEscapeString(n.Value)
 	s = ReplaceDoubleCurlyBracketsWithEntity(s)
 	hw.writeString(strings.Replace(s, "\n", "<br>", -1))
@@ -165,9 +162,6 @@ func (hw *htmlWriter) text(n *types.TextNode) {
 	}
 	if n.Bold {
 		hw.writeString("</strong>")
-	}
-	if !n.Bold && !n.Italic && !n.Code {
-		hw.writeString("</span>")
 	}
 }
 
@@ -245,12 +239,34 @@ func (hw *htmlWriter) code(n *types.CodeNode) {
 func (hw *htmlWriter) list(n *types.ListNode) {
 	wrap := n.Block() == true
 	if wrap {
-		hw.writeString("<p>")
+		if onlyImages(n.Nodes...) {
+			hw.writeString(`<p class="image-container">`)
+		} else {
+			hw.writeString("<p>")
+		}
 	}
 	hw.write(n.Nodes...)
 	if wrap {
 		hw.writeString("</p>")
 	}
+}
+
+// Returns true if the list of Nodes contains only images or white spaces.
+func onlyImages(nodes ...types.Node) bool {
+	for _, n := range nodes {
+		switch n := n.(type) {
+		case *types.TextNode:
+			if len(strings.TrimSpace(n.Value)) != 0 {
+				continue
+			}
+			return false
+		case *types.ImageNode:
+			continue
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 func (hw *htmlWriter) itemsList(n *types.ItemsListNode) {

--- a/claat/render/html.go
+++ b/claat/render/html.go
@@ -151,6 +151,9 @@ func (hw *htmlWriter) text(n *types.TextNode) {
 	if n.Code {
 		hw.writeString("<code>")
 	}
+	if !n.Bold && !n.Italic && !n.Code {
+		hw.writeString("<span>")
+	}
 	s := htmlTemplate.HTMLEscapeString(n.Value)
 	s = ReplaceDoubleCurlyBracketsWithEntity(s)
 	hw.writeString(strings.Replace(s, "\n", "<br>", -1))
@@ -162,6 +165,9 @@ func (hw *htmlWriter) text(n *types.TextNode) {
 	}
 	if n.Bold {
 		hw.writeString("</strong>")
+	}
+	if !n.Bold && !n.Italic && !n.Code {
+		hw.writeString("</span>")
 	}
 }
 

--- a/codelab-elements/google-codelab-step/google_codelab_step.scss
+++ b/codelab-elements/google-codelab-step/google_codelab_step.scss
@@ -318,4 +318,5 @@ google-codelab-step .youtube-video {
   height: 315px;
   border: none;
   max-width: 100%;
+  max-height: 51vw;
 }

--- a/codelab-elements/google-codelab-step/google_codelab_step.scss
+++ b/codelab-elements/google-codelab-step/google_codelab_step.scss
@@ -230,9 +230,8 @@ google-codelab-step .instructions img {
   vertical-align: bottom;
 }
 
-google-codelab-step .instructions img:only-child {
-  display: flex;
-  margin: auto;
+google-codelab-step .instructions .image-container {
+  text-align: center;
 }
 
 google-codelab-step .instructions table {

--- a/codelab-elements/google-codelab-step/google_codelab_step.scss
+++ b/codelab-elements/google-codelab-step/google_codelab_step.scss
@@ -230,6 +230,11 @@ google-codelab-step .instructions img {
   vertical-align: bottom;
 }
 
+google-codelab-step .instructions img:only-child {
+  display: flex;
+  margin: auto;
+}
+
 google-codelab-step .instructions table {
   border-spacing: 0;
 }
@@ -307,6 +312,8 @@ google-codelab-step .instructions h3 > a[href*="github"]:visited {
 }
 
 google-codelab-step .youtube-video {
+  display: flex;
+  margin: auto;
   width: 560px;
   height: 315px;
   border: none;


### PR DESCRIPTION
fixes #114 

This makes sure only images that are on their own lines are centered. And won't do anything to images that are inline text or if there are multiple images on the same line.

caveat: it adds a bunch of `<span></span>` to html output.

Example result:
![image](https://user-images.githubusercontent.com/3766663/54085799-1a521400-4342-11e9-9078-44f5c581c912.png)

![image](https://user-images.githubusercontent.com/3766663/54085805-33f35b80-4342-11e9-89db-d5e5eacf0e78.png)

