### PR TITLE
Redesign of the top bar

### DIFF
--- a/codelab-elements/google-codelab/_drawer.scss
+++ b/codelab-elements/google-codelab/_drawer.scss
@@ -21,7 +21,7 @@ google-codelab #drawer {
   flex-shrink: 0;
   position: relative;
   border-right: 1px solid #DADCE0;
-  z-index: 100;
+  z-index: 1001;
   display: flex;
   flex-direction: column;
 }
@@ -206,7 +206,7 @@ google-codelab #drawer {
     left: 0;
     top: 0;
     bottom: 0;
-    z-index: 1000;
+    z-index: 1001;
     will-change: transform;
     box-shadow: 2px 2px 4px rgba(0, 0, 0, 0);
     pointer-events: none;

--- a/codelab-elements/google-codelab/google_codelab.js
+++ b/codelab-elements/google-codelab/google_codelab.js
@@ -131,6 +131,9 @@ class Codelab extends HTMLElement {
     this.stepsContainer_ = null;
 
     /** @private {?Element} */
+    this.timeContainer_ = null;
+
+    /** @private {?Element} */
     this.titleContainer_ = null;
 
     /** @private {?Element} */
@@ -540,7 +543,7 @@ class Codelab extends HTMLElement {
    * @private
    */
   updateTimeRemaining_() {
-    if (!this.titleContainer_) {
+    if (!this.timeContainer_) {
       return;
     }
 
@@ -554,11 +557,11 @@ class Codelab extends HTMLElement {
     }
 
     const newTimeEl =  soy.renderAsElement(Templates.timeRemaining, {time});
-    const oldTimeEl = this.titleContainer_.querySelector('#time-remaining');
+    const oldTimeEl = this.timeContainer_.querySelector('#time-remaining');
     if (oldTimeEl) {
       dom.replaceNode(newTimeEl, oldTimeEl);
     } else {
-      dom.appendChild(this.titleContainer_, newTimeEl);
+      dom.appendChild(this.timeContainer_, newTimeEl);
     }
   }
 
@@ -802,6 +805,7 @@ class Codelab extends HTMLElement {
 
     this.drawer_ = this.querySelector('#drawer');
     this.titleContainer_ = this.querySelector('#codelab-title');
+    this.timeContainer_ = this.querySelector('#codelab-time-container');
     this.stepsContainer_ = this.querySelector('#steps');
     this.controls_ = this.querySelector('#controls');
     this.prevStepBtn_ = this.querySelector('#controls #previous-step');

--- a/codelab-elements/google-codelab/google_codelab.scss
+++ b/codelab-elements/google-codelab/google_codelab.scss
@@ -67,6 +67,7 @@ google-codelab #codelab-title #time-remaining {
   align-items: center;
   font-size: 16px;
   font-weight: 400;
+  white-space: nowrap;
 }
 
 google-codelab #codelab-title #time-remaining i {

--- a/codelab-elements/google-codelab/google_codelab.scss
+++ b/codelab-elements/google-codelab/google_codelab.scss
@@ -19,6 +19,7 @@ google-codelab {
   display: flex;
   width: 100%;
   height: 100%;
+  padding-top: 64px;
 }
 
 google-codelab #main {
@@ -30,6 +31,10 @@ google-codelab #main {
 }
 
 google-codelab #codelab-title {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
   background: #FFFFFF;
   box-shadow: 0px 1px 2px 0px rgba(60, 64, 67, 0.3), 0px 2px 6px 2px rgba(60, 64, 67, 0.15);
   color: #3C4043;
@@ -37,9 +42,9 @@ google-codelab #codelab-title {
   align-items: center;
   justify-content: space-between;
   height: 64px;
-  padding: 0 16px;
+  padding: 0 36px 0 16px;
   -webkit-font-smoothing: antialiased;
-  z-index: 99;
+  z-index: 1000;
 }
 
 google-codelab #codelab-title h1 {

--- a/codelab-elements/google-codelab/google_codelab.soy
+++ b/codelab-elements/google-codelab/google_codelab.soy
@@ -23,13 +23,15 @@
 {template .structure}
   {@param homeUrl: string}
   <div id="drawer">Drawer</div>
-  <div id="main">
-    <div id="codelab-title">
-      <div id="codelab-nav-buttons">
-        <a href="{$homeUrl}" id="arrow-back"><i class="material-icons">arrow_back</i></a>
-        <a href="#" id="menu"><i class="material-icons">menu</i></a>
-      </div>
+  <div id="codelab-title">
+    <div id="codelab-nav-buttons">
+      <a href="{$homeUrl}" id="arrow-back"><i class="material-icons">close</i></a>
+      <a href="#" id="menu"><i class="material-icons">menu</i></a>
     </div>
+    <div id="codelab-time-container"></div>
+    <devsite-user></devsite-user>
+  </div>
+  <div id="main">
     <div id="steps"></div>
     <div id="controls">
       <div id="fabs">


### PR DESCRIPTION
 - Make the top bar full width.
 - Change the "back arrow" buttont to "close" button.
 - Added a placeholder custom element where sign-in/profile should be displayed.

This changes the design of the top bar from this:

![image](https://user-images.githubusercontent.com/3766663/54772547-dc89a100-4c07-11e9-9ad8-bbb67461c460.png)

To this:

![image](https://user-images.githubusercontent.com/3766663/54772658-19559800-4c08-11e9-9ace-eab2e35af18e.png)

And potentially on websites that want to implement the sign-in/profile custom element (not shipped in this open-source repo) this could look like:

![image](https://user-images.githubusercontent.com/3766663/54772756-5de13380-4c08-11e9-8886-42b8b264190f.png)

