### PR TITLE
Removed call to non-existant scrollIntoViewIfNeeded, addressing issue #199

### DIFF
--- a/codelab-elements/google-codelab/google_codelab.js
+++ b/codelab-elements/google-codelab/google_codelab.js
@@ -712,7 +712,6 @@ class Codelab extends HTMLElement {
         }
         if (i === selected) {
           step.setAttribute(SELECTED_ATTR, '');
-          step.scrollIntoViewIfNeeded();
         } else {
           step.removeAttribute(SELECTED_ATTR);
         }


### PR DESCRIPTION
This address issue #199 

(I've got a signed Google CLA)