### PR TITLE
Moved e.preventDefault() and e.stopPropagation() in the handleDrawerC…

### DIFF
--- a/codelab-elements/google-codelab/google_codelab.js
+++ b/codelab-elements/google-codelab/google_codelab.js
@@ -496,14 +496,14 @@ class Codelab extends HTMLElement {
    * @private
    */
   handleDrawerClick_(e) {
-    e.preventDefault();
-    e.stopPropagation();
     let target = /** @type {!Element} */ (e.target);
 
     while (target !== this.drawer_) {
       if (target.tagName.toUpperCase() === 'A') {
         break;
       }
+      e.preventDefault();
+      e.stopPropagation();
       target = /** @type {!Element} */ (target.parentNode);
     }
 


### PR DESCRIPTION
…lick_() function to allow A tags to be properly followed on click event.  Addresses issue #201