### PR TITLE
[proto-definitions - Part 2] Deleting Table from proto

### DIFF
--- a/third_party/tutorial.proto
+++ b/third_party/tutorial.proto
@@ -45,6 +45,8 @@ message BlockContent {
     Image image = 2;
     InfoBox info_box = 3;
     CodeBlock code_block = 4;
+
+    reserved 5, 6;
   }
 };
 

--- a/third_party/tutorial.proto
+++ b/third_party/tutorial.proto
@@ -1,0 +1,123 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package devrel.tutorial;
+
+message Tutorial {
+  Title title = 1;
+  map<string, string> metadata = 2;
+  repeated Step steps = 3;
+};
+
+message Step {
+  Title title = 1;
+  map<string, string> metadata = 2;
+  repeated Content content = 3;
+};
+
+message Title {
+  repeated InlineContent inline_contents = 1;
+};
+
+message Content {
+  oneof content {
+    InlineContent inline_content = 1;
+    BlockContent block_content = 2;
+  }
+};
+
+message BlockContent {
+  oneof content {
+    Heading heading = 1;
+    Image image = 2;
+    InfoBox info_box = 3;
+    CodeBlock code_block = 4;
+    HorizontalRule horizontal_rule = 5;
+    Table table = 6;
+  }
+};
+
+message HorizontalRule {
+  // No fields.
+};
+
+message Link {
+  string text = 1;
+  string location = 2;
+};
+
+message InlineContent {
+  oneof content {
+    string text = 1;
+    string strong_text = 2;
+    string emphasized_text = 3;
+    string inline_code_text = 4;
+    Link link = 5;
+  }
+};
+
+message Heading {
+  repeated InlineContent inline_contents = 1;
+  int32 level = 2;
+};
+
+message Image {
+  // TODO
+};
+
+message InfoBox {
+  repeated InlineContent inline_contents = 1;
+
+  enum Disposition {
+    UNKNOWN_DISPOSITION = 0;
+    POSITIVE = 1;
+    NEGATIVE = 2;
+  };
+  Disposition disposition = 2;
+};
+
+message CodeBlock {
+  repeated InlineContent inline_contents = 1;
+  string code_location = 2;
+  string language_hint = 3;
+};
+
+message ListStep {
+  repeated Content contents = 1;
+};
+
+message List {
+  repeated ListStep list_steps = 1;
+
+  enum ListVariety {
+    UNKNOWN_VARIETY = 0;
+    ORDERED = 1;
+    UNORDERED = 2;
+  }
+  ListVariety list_variety = 2;
+};
+
+message Table {
+  repeated TableRow table_rows = 1;
+};
+
+message TableRow {
+  repeated TableCell table_cells = 1;
+};
+
+message TableCell {
+  repeated InlineContent inline_contents = 1;
+};

--- a/third_party/tutorial.proto
+++ b/third_party/tutorial.proto
@@ -45,13 +45,8 @@ message BlockContent {
     Image image = 2;
     InfoBox info_box = 3;
     CodeBlock code_block = 4;
-    HorizontalRule horizontal_rule = 5;
     Table table = 6;
   }
-};
-
-message HorizontalRule {
-  // No fields.
 };
 
 message Link {

--- a/third_party/tutorial.proto
+++ b/third_party/tutorial.proto
@@ -45,7 +45,6 @@ message BlockContent {
     Image image = 2;
     InfoBox info_box = 3;
     CodeBlock code_block = 4;
-    Table table = 6;
   }
 };
 
@@ -103,16 +102,4 @@ message List {
     UNORDERED = 2;
   }
   ListVariety list_variety = 2;
-};
-
-message Table {
-  repeated TableRow table_rows = 1;
-};
-
-message TableRow {
-  repeated TableCell table_cells = 1;
-};
-
-message TableCell {
-  repeated InlineContent inline_contents = 1;
 };


### PR DESCRIPTION
Part of #247
Deleting `Table` Type as it's unused.

`CodeBlock`s, `InfoBox`es, and `Survey`s are the only elements that use "Table" as formatting in GDocs, but this format does not carry over to Markdown. Deleting to have a cleaner 1=>1 mapping of Types. 

Ideally, `Step` contents will be `repeated BlockContent`, and `BlockContent` will have all possible types that require special processing.

In a Future PR (#257) `Surveys` will be introduced.