### PR TITLE
[proto-definitions - Part 3] No more special type for titles

### DIFF
--- a/third_party/tutorial.proto
+++ b/third_party/tutorial.proto
@@ -17,19 +17,19 @@ syntax = "proto3";
 package devrel.tutorial;
 
 message Tutorial {
-  Title title = 1;
+  string title = 4;
   map<string, string> metadata = 2;
   repeated Step steps = 3;
+
+  reserved 1;
 };
 
 message Step {
-  Title title = 1;
+  string title = 4;
   map<string, string> metadata = 2;
   repeated Content content = 3;
-};
 
-message Title {
-  repeated InlineContent inline_contents = 1;
+  reserved 1;
 };
 
 message Content {


### PR DESCRIPTION
Part of #247
Titles for are strings with different formatting for each parent-type. Does not deserve own subtype since it's a custom mapping for each (`Tutorial`, `Step`).

I'm attempting to maintain one proto-type per individual component.