### PR TITLE
[proto-definitions - Part 4] Replace `Heading` content type to a plain string

### DIFF
--- a/third_party/tutorial.proto
+++ b/third_party/tutorial.proto
@@ -69,7 +69,7 @@ message Heading {
   string text = 1;
   int32 level = 2;
 
-  reserved 1;
+  reserved 1, "inline_contents";
 };
 
 message Image {

--- a/third_party/tutorial.proto
+++ b/third_party/tutorial.proto
@@ -66,8 +66,10 @@ message InlineContent {
 };
 
 message Heading {
-  repeated InlineContent inline_contents = 1;
+  string text = 1;
   int32 level = 2;
+
+  reserved 1;
 };
 
 message Image {

--- a/third_party/tutorial.proto
+++ b/third_party/tutorial.proto
@@ -69,7 +69,8 @@ message Heading {
   string text = 1;
   int32 level = 2;
 
-  reserved 1, "inline_contents";
+  reserved 1;
+  reserved "inline_contents";
 };
 
 message Image {

--- a/third_party/tutorial.proto
+++ b/third_party/tutorial.proto
@@ -66,7 +66,7 @@ message InlineContent {
 };
 
 message Heading {
-  string text = 1;
+  string text = 3;
   int32 level = 2;
 
   reserved 1;


### PR DESCRIPTION
Part of #247
Having special formatting (italics, bold) on Headings seems like overkill. Making their content as a plain string. The case of GitHub links that are formatted as Headings will be changed on the parser side, but these do not follow true/normal Headings rules.