### PR TITLE
[proto-definitions - Part 5] Change ListStep to be InlineContent

### DIFF
--- a/third_party/tutorial.proto
+++ b/third_party/tutorial.proto
@@ -45,6 +45,7 @@ message BlockContent {
     Image image = 2;
     InfoBox info_box = 3;
     CodeBlock code_block = 4;
+    List list = 7;
 
     reserved 5, 6;
   }
@@ -94,11 +95,13 @@ message CodeBlock {
 };
 
 message ListStep {
-  repeated Content contents = 1;
+  repeated InlineContent contents = 2;
+
+  reserved 1;
 };
 
 message List {
-  repeated ListStep list_steps = 1;
+  repeated ListStep steps = 1;
 
   enum ListVariety {
     UNKNOWN_VARIETY = 0;


### PR DESCRIPTION
Part of #247
No one should use lists for block content. Changed `ListStep` content to be `InlineContent` instead of `Content`. 

In a future PR (#258) `Content` will be deprecated, and `BlockContent` will be the first-class type citizen.