### PR TITLE
[proto-definitions - Part 6] Remove code_location from CodeBlocks

### DIFF
--- a/third_party/tutorial.proto
+++ b/third_party/tutorial.proto
@@ -92,7 +92,8 @@ message CodeBlock {
   string text = 4;
   string language_hint = 3;
 
-  reserved 1, "inline_contents", 2, "code_location";
+  reserved 1, 2;
+  reserved "inline_contents", "code_location";
 };
 
 message ListStep {

--- a/third_party/tutorial.proto
+++ b/third_party/tutorial.proto
@@ -89,9 +89,10 @@ message InfoBox {
 };
 
 message CodeBlock {
-  repeated InlineContent inline_contents = 1;
-  string code_location = 2;
+  string text = 4;
   string language_hint = 3;
+
+  reserved 1, 2;
 };
 
 message ListStep {

--- a/third_party/tutorial.proto
+++ b/third_party/tutorial.proto
@@ -92,7 +92,7 @@ message CodeBlock {
   string text = 4;
   string language_hint = 3;
 
-  reserved 1, 2;
+  reserved 1, "inline_contents", 2, "code_location";
 };
 
 message ListStep {


### PR DESCRIPTION
Part of #247
`code_location`: `CodeBlock`s and its code location are not tightly coupled.  In a future PR, this will be represented as a styled `Link` since it follows a similar styling to the `FAQ` styled icons (`code_location` links are links to bold links to GitHub with a prepended favicon, same as we have for StackOverflow, GCloud, etc)

`inline_contents`: I am not aware of how the automating syntax highlighting is done, but unless specified (font text is `Courier New` on GDoc), there is no special parsing done to the text/content of the table. Making this a string for such reason.