### PR TITLE
[proto-definitions - Part 8] BlockContent is now main type of Steps

### DIFF
--- a/third_party/tutorial.proto
+++ b/third_party/tutorial.proto
@@ -27,16 +27,9 @@ message Tutorial {
 message Step {
   string title = 4;
   map<string, string> metadata = 2;
-  repeated Content content = 3;
+  repeated BlockContent content = 5;
 
-  reserved 1;
-};
-
-message Content {
-  oneof content {
-    InlineContent inline_content = 1;
-    BlockContent block_content = 2;
-  }
+  reserved 1, 3;
 };
 
 message BlockContent {
@@ -55,11 +48,6 @@ message BlockContent {
   }
 };
 
-message Link {
-  string text = 1;
-  string location = 2;
-};
-
 message InlineContent {
   oneof content {
     string text = 1;
@@ -68,6 +56,11 @@ message InlineContent {
     string inline_code_text = 4;
     Link link = 5;
   }
+};
+
+message Link {
+  string text = 1;
+  string location = 2;
 };
 
 message Heading {
@@ -99,12 +92,6 @@ message CodeBlock {
   reserved 1, "inline_contents", 2, "code_location";
 };
 
-message ListStep {
-  repeated InlineContent contents = 2;
-
-  reserved 1;
-};
-
 message List {
   repeated ListStep steps = 1;
 
@@ -114,6 +101,12 @@ message List {
     UNORDERED = 2;
   }
   ListVariety list_variety = 2;
+};
+
+message ListStep {
+  repeated InlineContent contents = 2;
+
+  reserved 1;
 };
 
 message Survey {

--- a/third_party/tutorial.proto
+++ b/third_party/tutorial.proto
@@ -46,6 +46,10 @@ message BlockContent {
     InfoBox info_box = 3;
     CodeBlock code_block = 4;
     List list = 7;
+    Survey survey = 8;
+    Checklist checklist = 9;
+    FAQ faq = 10;
+    Button button = 11;
 
     reserved 5, 6;
   }
@@ -111,3 +115,23 @@ message List {
   }
   ListVariety list_variety = 2;
 };
+
+message Survey {
+  string title = 1;
+  List questions = 2;
+}
+
+message Checklist {
+  string title = 1;
+  List items = 2;
+}
+
+message FAQ {
+  string title = 1;
+  List questions = 2;
+}
+
+message Button {
+  Link link = 1;
+  bool isDownloadButton = 2;
+}

--- a/third_party/tutorial.proto
+++ b/third_party/tutorial.proto
@@ -39,13 +39,9 @@ message BlockContent {
     InfoBox info_box = 3;
     CodeBlock code_block = 4;
     List list = 7;
-    Survey survey = 8;
-    Checklist checklist = 9;
-    FAQ faq = 10;
-    Button button = 11;
-
-    reserved 5, 6;
   }
+
+  reserved 5, 6;
 };
 
 message InlineContent {
@@ -108,23 +104,3 @@ message ListStep {
 
   reserved 1;
 };
-
-message Survey {
-  string title = 1;
-  List questions = 2;
-}
-
-message Checklist {
-  string title = 1;
-  List items = 2;
-}
-
-message FAQ {
-  string title = 1;
-  List questions = 2;
-}
-
-message Button {
-  Link link = 1;
-  bool isDownloadButton = 2;
-}


### PR DESCRIPTION
Part of #247
Refactor: Types are now shows as they appear by Depth-First (immediately define new types that show up, go back once a chain is done, repeat until done).

In a Future PR, repeated `InlineContent`s will be merged into a new type, called `Paragraph` (ideas on this welcomed), which will be added to `BlockContent`, and will replace other `repeated InlineContent`.