### PR TITLE
[proto-build-system Part 1] Added protobuf building to current build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bazel-*
 .drone.sec.yml
 .idea/
 debug.test
+*.pb.go

--- a/claat/Makefile
+++ b/claat/Makefile
@@ -30,6 +30,7 @@ SRCS = $(shell find . -name '*.go') render/tmpldata.go
 all: $(OUTDIR)/claat
 
 $(OUTDIR)/claat: $(SRCS) VERSION
+	protoc tutorial.proto -I=../third_party --go_out=../third_party
 	go build -o $@ -ldflags "-X main.version=$(VERSION)"
 
 serve: $(OUTDIR)/claat


### PR DESCRIPTION
Part of #247 
This will makes our protobuf compile to the latest version before compiling the entire tool. Protobuf syntax errors will appear upon `make`. 

In a Future PR, once proto definitions stabilize, simple definition and extraction tests will be done to all proto fields.