### PR TITLE
[proto-render-setup Part 1]: Intended template definitions

### DIFF
--- a/third_party/render_globals.go
+++ b/third_party/render_globals.go
@@ -1,0 +1,18 @@
+package devrel_tutorial
+
+import (
+	"bytes"
+	"log"
+	"text/template"
+)
+
+// Reviewing comment: Templates can live anywhere within the repo
+const (
+  mdTmplsDir = 	"github.com/googlecodelabs/tools/third_party/templates/md/*"
+  htmlTmplsDir = 	"github.com/googlecodelabs/tools/third_party/templates/html/*"
+)
+
+var (
+	md   *template.Template
+	html *template.Template
+)

--- a/third_party/render_html.go
+++ b/third_party/render_html.go
@@ -1,0 +1,10 @@
+package devrel_tutorial
+
+import (
+	"strings"
+	"text/template"
+)
+
+func init() {
+	html = template.Must(template.New("master").ParseGlob(htmlTmplsDir))
+}

--- a/third_party/render_md.go
+++ b/third_party/render_md.go
@@ -1,0 +1,10 @@
+package devrel_tutorial
+
+import (
+	"strings"
+	"text/template"
+)
+
+func init() {
+	md = template.Must(template.New("master").ParseGlob(mdTmplsDir))
+}


### PR DESCRIPTION
Part of #247, ignore possible 'unused' packages - they're taken care of by #272

Not using `html\templates` as for default HTML rendering as they escape characters too much and that adds overhead (https://github.com/golang/go/issues/20842, https://stackoverflow.com/questions/31361745/slow-performance-of-html-template-in-go-lang-any-workaround). Only some Leaf types (`StylizedText`, `InlineCode`, `Heading` and `CodeBlock` - at least that I can think of now) need escaping as they're the only ones we're transferring direct user input. Side note: I'll create a chart/drawing depiciting these metatypes groups (Leaf, Oneof, Repeated), they'll be obvious why we need the distinction in a few PRs.

I'd probably prefer to move this out of `third_party` and into somewhere else more semantically meaning eventually. Extending proto package per #265 "Proto definitions extension". 

Advantage of this is no need to maintain a master switch-statement delegating the _actual_ rendering to sub-rendering functions, and rendering will come out-of-the-box once you import the proto package. Also, fewer steps to add new types in the future with compile-type checks for interface method implementations (see #273 for an example).

Will not attempt to reimplement the switch-based rendering interface the current non-proto render implements unless some working code is provided, as this would require an extra type/proto. More explanations on #265 bottom "PS" section, and TODOs on #272.

This explanation carries over to the next 2 PRs