### PR TITLE
[proto-render-templating Part 1] 'StylizedText'. Allows for simultaneous italics and boldening

### DIFF
--- a/third_party/render_html.go
+++ b/third_party/render_html.go
@@ -18,3 +18,7 @@ func init() {
 func (el *Heading) Html() string {
 	return executeTemplate(&el, "Heading", html)
 }
+
+func (el *StylizedText) Html() string {
+	return executeTemplate(&el, "StylizedText", html)
+}

--- a/third_party/render_html_test.go
+++ b/third_party/render_html_test.go
@@ -26,3 +26,30 @@ func TestRenderHtmlHeading(t *testing.T) {
 	}
 	util.TestBatch(tests, t)
 }
+
+func TestRenderHtmlStylizedText(t *testing.T) {
+	p := &StylizedText{
+		Text: "hello!",
+	}
+	b := &StylizedText{
+		Text:   "hello!",
+		IsBold: true,
+	}
+	i := &StylizedText{
+		Text:         "hello!",
+		IsEmphasized: true,
+	}
+	b_i := &StylizedText{
+		Text:         "hello!",
+		IsBold:       true,
+		IsEmphasized: true,
+	}
+
+	tests := []*util.TestingBatch{
+		{p.Html(), "hello!"},
+		{b.Html(), "<strong>hello!</strong>"},
+		{i.Html(), "<em>hello!</em>"},
+		{b_i.Html(), "<strong><em>hello!</em></strong>"},
+	}
+	util.TestBatch(tests, t)
+}

--- a/third_party/render_md.go
+++ b/third_party/render_md.go
@@ -22,3 +22,7 @@ func init() {
 func (el *Heading) Md() string {
 	return executeTemplate(&el, "Heading", md)
 }
+
+func (el *StylizedText) Md() string {
+	return executeTemplate(&el, "StylizedText", md)
+}

--- a/third_party/render_md_test.go
+++ b/third_party/render_md_test.go
@@ -25,3 +25,29 @@ func TestRenderHeadingMd(t *testing.T) {
 	}
 	util.TestBatch(tests, t)
 }
+
+func TestRenderHtmlStylizedText(t *testing.T) {
+	p := &StylizedText{
+		Text: "hello!",
+	}
+	b := &StylizedText{
+		Text:   "hello!",
+		IsBold: true,
+	}
+	i := &StylizedText{
+		Text:         "hello!",
+		IsEmphasized: true,
+	}
+	b_i := &StylizedText{
+		Text:         "hello!",
+		IsBold:       true,
+		IsEmphasized: true,
+	}
+	tests := []*util.TestingBatch{
+		{p.Md(), "hello!"},
+		{b.Md(), "**hello!**"},
+		{i.Md(), "__hello!__"},
+		{b_i.Md(), "**__hello!__**"},
+	}
+	util.TestBatch(tests, t)
+}

--- a/third_party/templates/html/StylizedText
+++ b/third_party/templates/html/StylizedText
@@ -1,0 +1,5 @@
+{{- if .IsBold -}} <strong> {{- end -}}
+{{- if .IsEmphasized -}} <em> {{- end -}}
+{{- .Text | html | js -}}
+{{- if .IsEmphasized -}} </em> {{- end -}}
+{{- if .IsBold -}} </strong> {{- end -}}

--- a/third_party/templates/md/StylizedText
+++ b/third_party/templates/md/StylizedText
@@ -1,0 +1,5 @@
+{{- if .IsBold -}} ** {{- end -}}
+{{- if .IsEmphasized -}} __ {{- end -}}
+{{- .Text -}}
+{{- if .IsEmphasized -}} __ {{- end -}}
+{{- if .IsBold -}} ** {{- end -}}

--- a/third_party/tutorial.proto
+++ b/third_party/tutorial.proto
@@ -59,13 +59,21 @@ message Link {
 
 message InlineContent {
   oneof content {
-    string text = 1;
+    StylizedText text = 6;
     string strong_text = 2;
     string emphasized_text = 3;
     string inline_code_text = 4;
     Link link = 5;
   }
+
+  reserved 1;
 };
+
+message StylizedText {
+  string text = 1;
+  bool is_bold = 2;
+  bool is_emphasized = 3;
+}
 
 message Heading {
   repeated InlineContent inline_contents = 1;

--- a/third_party/tutorial.proto
+++ b/third_party/tutorial.proto
@@ -60,13 +60,11 @@ message Link {
 message InlineContent {
   oneof content {
     StylizedText text = 6;
-    string strong_text = 2;
-    string emphasized_text = 3;
-    string inline_code_text = 4;
     Link link = 5;
   }
 
-  reserved 1;
+  reserved 1, 2, 3, 4;
+  reserved "strong_text", "emphasized_text", "inline_code_text";
 };
 
 message StylizedText {


### PR DESCRIPTION
Part of #247

In a future PR, `Links` will also be allowed to be of simultaneously bold and italics.
Missing from `InlineContent`: yet-to-be-pushed `InlineCode` proto-type.