### PR TITLE
Fix for Expired Access Token

### DIFF
--- a/claat/cmd/auth.go
+++ b/claat/cmd/auth.go
@@ -69,7 +69,8 @@ func init() {
 func driveClient(authToken string) (*http.Client, error) {
 	clientsMu.Lock()
 	defer clientsMu.Unlock()
-	if hc, ok := clients[providerGoogle]; ok {
+	provider := providerGoogle + authToken;
+	if hc, ok := clients[provider]; ok {
 		return hc, nil
 	}
 	ts, err := tokenSource(providerGoogle, authToken)
@@ -81,7 +82,7 @@ func driveClient(authToken string) (*http.Client, error) {
 		Base:   http.DefaultTransport,
 	}
 	hc := &http.Client{Transport: t}
-	clients[providerGoogle] = hc
+	clients[provider] = hc
 	return hc, nil
 }
 


### PR DESCRIPTION
Part of #274 
 
If a user supplies a new access token through the command line flag, the Drive API fails because the driveClient function still returns credentials generated using the previously expired access token.