### PR TITLE
[reviewed-proto-renderer-setup]: Generic Renderer with sample template namespace tests

### DIFF
--- a/claat/proto-renderer/generic_renderer.go
+++ b/claat/proto-renderer/generic_renderer.go
@@ -14,7 +14,7 @@ func ExecuteTemplate(el interface{}, t *template.Template) string {
 	e := t.ExecuteTemplate(&w, reflect.TypeOf(el).Name(), el)
 	if e != nil {
 		// This method outputs directly to templates. Panicking to surfance errors
-		//   since we cannot handle multiple returns in templates
+		// since we cannot handle multiple returns in templates.
 		// Panics will be gracefully handled by a wrapper function
 		panic(fmt.Sprintf("Templating panic: %s\n", e))
 	}

--- a/claat/proto-renderer/generic_renderer.go
+++ b/claat/proto-renderer/generic_renderer.go
@@ -1,0 +1,19 @@
+package genrenderer
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"text/template"
+)
+
+// ExecuteTemplate returns the evaluated template per passed templating
+// namespace, based on the passed Codelab proto element type
+func ExecuteTemplate(el interface{}, t *template.Template) string {
+	var w bytes.Buffer
+	e := t.ExecuteTemplate(&w, reflect.TypeOf(el).Name(), el)
+	if e != nil {
+		panic(fmt.Sprintf("Templating err: %s\n", e))
+	}
+	return w.String()
+}

--- a/claat/proto-renderer/generic_renderer.go
+++ b/claat/proto-renderer/generic_renderer.go
@@ -13,7 +13,10 @@ func ExecuteTemplate(el interface{}, t *template.Template) string {
 	var w bytes.Buffer
 	e := t.ExecuteTemplate(&w, reflect.TypeOf(el).Name(), el)
 	if e != nil {
-		panic(fmt.Sprintf("Templating err: %s\n", e))
+		// This method outputs directly to templates. Panicking to surfance errors
+		//   since we cannot handle multiple returns in templates
+		// Panics will be gracefully handled by a wrapper function
+		panic(fmt.Sprintf("Templating panic: %s\n", e))
 	}
 	return w.String()
 }

--- a/claat/proto-renderer/generic_renderer_test.go
+++ b/claat/proto-renderer/generic_renderer_test.go
@@ -30,9 +30,9 @@ func TestExecuteTemplate(t *testing.T) {
 	tmpl := template.Must(template.New("dummy").Funcs(funcMap).ParseGlob(tmplsAbsDir))
 
 	tests := []encapsulatedTest{
-		{newSampleProtoTemplate(3), "3", false},
-		{newSampleProtoTemplate(nil), "", true},
-		{newSampleProtoTemplate("not-valid"), "", true},
+		{newSampleProtoTemplate(3), "3", true},
+		{newSampleProtoTemplate(nil), "", false},
+		{newSampleProtoTemplate("not-valid"), "", false},
 	}
 
 	for _, tc := range tests {

--- a/claat/proto-renderer/generic_renderer_test.go
+++ b/claat/proto-renderer/generic_renderer_test.go
@@ -1,0 +1,59 @@
+package genrenderer
+
+import (
+	"go/build"
+	"path/filepath"
+	"testing"
+	"text/template"
+)
+
+type encapsulatedTest struct {
+	In      sampleProtoTemplate
+	Out     string
+	WantErr bool
+}
+
+type sampleProtoTemplate struct {
+	Value interface{}
+}
+
+func newSampleProtoTemplate(el interface{}) sampleProtoTemplate {
+	return sampleProtoTemplate{Value: el}
+}
+
+func runEncapsulatedTest(test encapsulatedTest, tmpl *template.Template, t *testing.T) {
+	// Check wheather template failed to render by checking if there was a panic
+	defer func(test encapsulatedTest) {
+		r := recover()
+		if r != nil && !test.WantErr {
+			t.Errorf("False positive panic for: %+v", test)
+		}
+
+		if r == nil && test.WantErr {
+			t.Errorf("False negative panic for: %+v", test)
+		}
+	}(test)
+
+	tmplOut := ExecuteTemplate(test.In, tmpl)
+	if test.Out != tmplOut && !test.WantErr {
+		t.Errorf("Expecting:\n\t'%s', but got \n\t'%s'", test.Out, test.In)
+	}
+}
+
+func TestExecuteTemplate(t *testing.T) {
+	tmplsRltvDir := "src/github.com/googlecodelabs/tools/claat/proto-renderer/testdata/*"
+	tmplsAbsDir := filepath.Join(build.Default.GOPATH, tmplsRltvDir)
+	funcMap := template.FuncMap{
+		"returnInt": func(i int) int { return i },
+	}
+	tmpl := template.Must(template.New("dummy").Funcs(funcMap).ParseGlob(tmplsAbsDir))
+
+	tests := []encapsulatedTest{
+		{newSampleProtoTemplate(3), "3", false},
+		{newSampleProtoTemplate("not-valid"), "", true},
+	}
+
+	for _, test := range tests {
+		runEncapsulatedTest(test, tmpl, t)
+	}
+}

--- a/claat/proto-renderer/generic_renderer_test.go
+++ b/claat/proto-renderer/generic_renderer_test.go
@@ -45,11 +45,11 @@ func runEncapsulatedTest(test encapsulatedTest, tmpl *template.Template, t *test
 	defer func(test encapsulatedTest) {
 		err := recover()
 		if err != nil && test.ok {
-			t.Errorf("\nFor:\n\t%#v\nPanic occured:\n\t%s\t(false negative)", test, err)
+			t.Errorf("\nExecuteTemplate(\n\t%#v,\n\t%v,\n) = %#v\nPanic occured:\n\t%#v\n(false negative)", test, tmpl, test.out, err)
 		}
 
 		if err == nil && !test.ok {
-			t.Errorf("\nPanic did not occur for:\n\t%#v\n\t(false positive)", test)
+			t.Errorf("\nExecuteTemplate(\n\t%#v,\n\t%v,\n) = %#v\nWant panic\n(false positive)", test, tmpl, test.out)
 		}
 	}(test)
 

--- a/claat/proto-renderer/generic_renderer_test.go
+++ b/claat/proto-renderer/generic_renderer_test.go
@@ -24,13 +24,13 @@ func newSampleProtoTemplate(el interface{}) sampleProtoTemplate {
 func runEncapsulatedTest(test encapsulatedTest, tmpl *template.Template, t *testing.T) {
 	// Check wheather template failed to render by checking if there was a panic
 	defer func(test encapsulatedTest) {
-		r := recover()
-		if r != nil && !test.WantErr {
-			t.Errorf("False positive panic for: %+v", test)
+		err := recover()
+		if err != nil && !test.WantErr {
+			t.Errorf("For: %#v\n\t%s", test, err)
 		}
 
-		if r == nil && test.WantErr {
-			t.Errorf("False negative panic for: %+v", test)
+		if err == nil && test.WantErr {
+			t.Errorf("Error did not occur for: %#v", test)
 		}
 	}(test)
 
@@ -50,6 +50,7 @@ func TestExecuteTemplate(t *testing.T) {
 
 	tests := []encapsulatedTest{
 		{newSampleProtoTemplate(3), "3", false},
+		{newSampleProtoTemplate(nil), "", true},
 		{newSampleProtoTemplate("not-valid"), "", true},
 	}
 

--- a/claat/proto-renderer/testdata/sampleProtoTemplate
+++ b/claat/proto-renderer/testdata/sampleProtoTemplate
@@ -1,0 +1,1 @@
+{{ returnInt .Value }}


### PR DESCRIPTION
A restart of #247 

Base logic for future protobuf-based renderer. On this one we use pure reflection to route types to their templates, but this will changes to a type-switch on a future PR.