### PR TITLE
Revert "Material icon 'cloud_download' replaces Polymer icon 'file-download'"

### DIFF
--- a/claat/render/html.go
+++ b/claat/render/html.go
@@ -217,7 +217,7 @@ func (hw *htmlWriter) button(n *types.ButtonNode) {
 	}
 	hw.writeBytes(greaterThan)
 	if n.Download {
-		hw.writeString(`<iron-icon icon="cloud_download"></iron-icon>`)
+		hw.writeString(`<iron-icon icon="file-download"></iron-icon>`)
 	}
 	hw.write(n.Content.Nodes...)
 	hw.writeString("</paper-button>")

--- a/codelab-elements/google-codelab/google_codelab.scss
+++ b/codelab-elements/google-codelab/google_codelab.scss
@@ -162,10 +162,6 @@ google-codelab #drawer .codelab-time-container {
   display: none;
 }
 
-iron-icon[icon="file-download"]::after {
-  content: 'cloud_download';
-}
-
 @media (max-width: 768px) {
   google-codelab #codelab-title .codelab-time-container {
     display: none;


### PR DESCRIPTION
Reverts #243 since #242 was did not resolved. Now all download buttons show 'cloud_download' as a literal prefix instead of wanted cloud icon. Issue updated with future steps.