### PR TITLE
[reviewed-proto-renderer Part 5]: Base Nested type rendering: Button

### DIFF
--- a/claat/proto-renderer/generic_renderer.go
+++ b/claat/proto-renderer/generic_renderer.go
@@ -21,6 +21,8 @@ func templateName(el interface{}) string {
 		return "Paragraph"
 	case *tutorial.Link, tutorial.Link:
 		return "Link"
+	case *tutorial.Button, tutorial.Button:
+		return "Button"
 	}
 	// This will cause a debug-friendly panic
 	return TypeNotSupported("genrenderer.templateName", el)

--- a/claat/proto-renderer/html/templates-tests/button_test.go
+++ b/claat/proto-renderer/html/templates-tests/button_test.go
@@ -1,0 +1,60 @@
+package htmltests
+
+import (
+	"go/build"
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/googlecodelabs/tools/claat/proto-renderer/html"
+	"github.com/googlecodelabs/tools/claat/proto-renderer/testing-utils"
+	"github.com/googlecodelabs/tools/third_party"
+)
+
+func TestRenderButtonTemplate(t *testing.T) {
+	// TODO: Generalize file reading logic
+	var fOuts []string
+	files := []string{
+		"plain.txt",
+		"download.txt",
+	}
+	for _, f := range files {
+		linkFileRelDir := "src/github.com/googlecodelabs/tools/claat/proto-renderer/html/templates-tests/testdata/Button"
+		linkFileAbsDir := filepath.Join(build.Default.GOPATH, linkFileRelDir, f)
+		fileBytes, err := ioutil.ReadFile(linkFileAbsDir)
+		if err != nil {
+			t.Errorf("Reading %#v outputted %#v", linkFileAbsDir, err)
+			continue
+		}
+		fOuts = append(fOuts, string(fileBytes[:]))
+	}
+
+	tests := []*testingutils.CanonicalRenderingBatch{
+		{
+			InProto: &tutorial.Button{},
+			Out:     "",
+			Ok:      false,
+		},
+		{
+			InProto: testingutils.NewButtonPlain(
+				testingutils.NewLink(
+					"www.cloud.io",
+					testingutils.NewStylizedTextPlain("hosting"),
+				),
+			),
+			Out: fOuts[0],
+			Ok:  true,
+		},
+		{
+			InProto: testingutils.NewButtonDownload(
+				testingutils.NewLink(
+					"www.random.org",
+					testingutils.NewStylizedTextPlain("FizzBuzz"),
+				),
+			),
+			Out: fOuts[1],
+			Ok:  true,
+		},
+	}
+	testingutils.CanonicalRenderTestBatch(html.Render, tests, t)
+}

--- a/claat/proto-renderer/html/templates-tests/inlinecontent_test.go
+++ b/claat/proto-renderer/html/templates-tests/inlinecontent_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestRenderInlineContentTemplateLinkFromFile(t *testing.T) {
+	// TODO: Generalize file reading logic
 	linkFileRelDir := "src/github.com/googlecodelabs/tools/claat/proto-renderer/html/templates-tests/testdata/InlineContent/google_weather.txt"
 	linkFileAbsDir := filepath.Join(build.Default.GOPATH, linkFileRelDir)
 	weatherLinkBytes, err := ioutil.ReadFile(linkFileAbsDir)

--- a/claat/proto-renderer/html/templates-tests/link_test.go
+++ b/claat/proto-renderer/html/templates-tests/link_test.go
@@ -36,7 +36,7 @@ func TestRenderLinkTemplate(t *testing.T) {
 			Ok:      false,
 		},
 		{
-			InProto: testingutils.NewLink("only://link.does.not/work?#ok"),
+			InProto: testingutils.NewLink("only://link.does.not/work?#ok=false"),
 			Out:     "",
 			Ok:      false,
 		},

--- a/claat/proto-renderer/html/templates-tests/testdata/Button/download.txt
+++ b/claat/proto-renderer/html/templates-tests/testdata/Button/download.txt
@@ -1,0 +1,4 @@
+<paper-button class="colored">
+  <iron-icon icon="cloud_download"></iron-icon>
+  <a target="_blank" href="www.random.org">FizzBuzz</a>
+</paper-button>

--- a/claat/proto-renderer/html/templates-tests/testdata/Button/plain.txt
+++ b/claat/proto-renderer/html/templates-tests/testdata/Button/plain.txt
@@ -1,0 +1,4 @@
+<paper-button class="colored">
+  
+  <a target="_blank" href="www.cloud.io">hosting</a>
+</paper-button>

--- a/claat/proto-renderer/html/templates/Button
+++ b/claat/proto-renderer/html/templates/Button
@@ -1,0 +1,4 @@
+<paper-button class="colored">
+  {{ if .IsDownloadable -}} <iron-icon icon="cloud_download"></iron-icon> {{- end }}
+  {{ template "Link" .Link }}
+</paper-button>

--- a/claat/proto-renderer/testing-utils/proto_constructors.go
+++ b/claat/proto-renderer/testing-utils/proto_constructors.go
@@ -34,13 +34,6 @@ func NewStylizedTextStrongAndEmphasized(txt string) *tutorial.StylizedText {
 	}
 }
 
-func NewLink(href string, contentSlice ...*tutorial.StylizedText) *tutorial.Link {
-	return &tutorial.Link{
-		Href:    href,
-		Content: contentSlice,
-	}
-}
-
 func NewInlineCode(txt string) *tutorial.InlineCode {
 	return &tutorial.InlineCode{
 		Code: txt,
@@ -57,10 +50,39 @@ func NewInlineContentCode(txt string) *tutorial.InlineContent {
 	}
 }
 
+func NewLink(href string, contentSlice ...*tutorial.StylizedText) *tutorial.Link {
+	return &tutorial.Link{
+		Href:    href,
+		Content: contentSlice,
+	}
+}
+
 func NewInlineContentLink(link *tutorial.Link) *tutorial.InlineContent {
 	return &tutorial.InlineContent{
 		Content: &tutorial.InlineContent_Link{
 			Link: link,
+		},
+	}
+}
+
+func NewButtonPlain(link *tutorial.Link) *tutorial.Button {
+	return &tutorial.Button{
+		Link: link,
+	}
+}
+
+func NewButtonDownload(link *tutorial.Link) *tutorial.Button {
+	return &tutorial.Button{
+		Link:           link,
+		IsDownloadable: true,
+	}
+}
+
+// TODO: Add this to InlineContent tests
+func NewInlineContentButton(button *tutorial.Button) *tutorial.InlineContent {
+	return &tutorial.InlineContent{
+		Content: &tutorial.InlineContent_Button{
+			Button: button,
 		},
 	}
 }

--- a/third_party/tutorial.proto
+++ b/third_party/tutorial.proto
@@ -60,11 +60,17 @@ message Link {
   reserved "text", "location";
 }
 
+message Button {
+  Link link = 1;
+  bool is_downloadable = 2;
+}
+
 message InlineContent {
   oneof content {
     StylizedText text = 1;
     Link link = 5;
     InlineCode code = 6;
+    Button button = 7;
   }
 
   reserved 2, 3, 4; 


### PR DESCRIPTION
Part of #247

Final type that demonstrates a new type of "rendering per nesting nature"
So far they've been as following
- Leaves: #288, #290
- Nested: #295 (this PR)
- Oneof: #291 
- Repeated: #292, #294

The next ~15 PRs will be based and in similar size to this one.
Type TODOs:
- `List`
- `TableRow`
- `Table`
- `InfoBox`
- `Heading`
- `Image`
- `ImageBlock`
- `YoutubeVideo`
- `CodeBlock`
- `Survey`
- `BlockContent`
- `Step`
- `Tutorial`

Delete:

- `Title`
- `Content` (decouple `BlockContent` and `InlineContent` branching)