### PR TITLE
Implement pass_metadata flag

### DIFF
--- a/claat/cmd/export.go
+++ b/claat/cmd/export.go
@@ -41,6 +41,8 @@ type CmdExportOptions struct {
 	GlobalGA string
 	// Output is the output directory, or "-" for stdout.
 	Output string
+	// PassMetadata are the extra metadata fields to pass along.
+	PassMetadata map[string]bool
 	// Prefix is a URL prefix to prepend when using HTML format.
 	Prefix string
 	// Srcs is the sources to export codelabs from.
@@ -91,7 +93,7 @@ func CmdExport(opts CmdExportOptions) int {
 // nothing is stored on disk and the only output, codelab formatted content,
 // is printed to stdout.
 func exportCodelab(src string, opts CmdExportOptions) (*types.Meta, error) {
-	clab, err := slurpCodelab(src, opts.AuthToken)
+	clab, err := slurpCodelab(src, opts.AuthToken, opts.PassMetadata)
 	if err != nil {
 		return nil, err
 	}

--- a/claat/cmd/fetch.go
+++ b/claat/cmd/fetch.go
@@ -70,7 +70,6 @@ type codelab struct {
 // The function will also fetch and parse fragments included
 // with types.ImportNode.
 func slurpCodelab(src, authToken string, passMetadata map[string]bool) (*codelab, error) {
-	// TODO use passMetadata
 	res, err := fetch(src, authToken)
 	if err != nil {
 		return nil, err

--- a/claat/cmd/fetch.go
+++ b/claat/cmd/fetch.go
@@ -64,11 +64,13 @@ type codelab struct {
 }
 
 // slurpCodelab retrieves and parses codelab source.
+// It takes the source, plus an auth token and a set of extra metadata to pass along.
 // It returns parsed codelab and its source type.
 //
 // The function will also fetch and parse fragments included
 // with types.ImportNode.
-func slurpCodelab(src, authToken string) (*codelab, error) {
+func slurpCodelab(src, authToken string, passMetadata map[string]bool) (*codelab, error) {
+	// TODO use passMetadata
 	res, err := fetch(src, authToken)
 	if err != nil {
 		return nil, err

--- a/claat/cmd/fetch.go
+++ b/claat/cmd/fetch.go
@@ -76,7 +76,9 @@ func slurpCodelab(src, authToken string, passMetadata map[string]bool) (*codelab
 		return nil, err
 	}
 	defer res.body.Close()
-	clab, err := parser.Parse(string(res.typ), res.body, parser.Options{})
+	clab, err := parser.Parse(string(res.typ), res.body, parser.Options{
+		PassMetadata: passMetadata,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/claat/cmd/fetch.go
+++ b/claat/cmd/fetch.go
@@ -76,7 +76,7 @@ func slurpCodelab(src, authToken string, passMetadata map[string]bool) (*codelab
 		return nil, err
 	}
 	defer res.body.Close()
-	clab, err := parser.Parse(string(res.typ), res.body)
+	clab, err := parser.Parse(string(res.typ), res.body, parser.Options{})
 	if err != nil {
 		return nil, err
 	}

--- a/claat/cmd/fetch.go
+++ b/claat/cmd/fetch.go
@@ -75,9 +75,11 @@ func slurpCodelab(src, authToken string, passMetadata map[string]bool) (*codelab
 		return nil, err
 	}
 	defer res.body.Close()
-	clab, err := parser.Parse(string(res.typ), res.body, parser.Options{
-		PassMetadata: passMetadata,
-	})
+
+	opts := *parser.NewOptions()
+	opts.PassMetadata = passMetadata
+
+	clab, err := parser.Parse(string(res.typ), res.body, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/claat/cmd/fetch_test.go
+++ b/claat/cmd/fetch_test.go
@@ -135,7 +135,7 @@ func TestSlurpWithFragment(t *testing.T) {
 	}}
 	clients[providerGoogle] = &http.Client{Transport: rt}
 
-	clab, err := slurpCodelab("doc-123", "")
+	clab, err := slurpCodelab("doc-123", "", map[string]bool{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/claat/cmd/update.go
+++ b/claat/cmd/update.go
@@ -39,6 +39,8 @@ type CmdUpdateOptions struct {
 	ExtraVars map[string]string
 	// GlobalGA is the global Google Analytics account to use.
 	GlobalGA string
+	// PassMetadata are the extra metadata fields to pass along.
+	PassMetadata map[string]bool
 	// Prefix is a URL prefix to prepend when using HTML format.
 	Prefix string
 }
@@ -105,7 +107,7 @@ func updateCodelab(dir string, opts CmdUpdateOptions) (*types.Meta, error) {
 	}
 
 	// fetch and parse codelab source
-	clab, err := slurpCodelab(meta.Source, opts.AuthToken)
+	clab, err := slurpCodelab(meta.Source, opts.AuthToken, opts.PassMetadata)
 	if err != nil {
 		return nil, err
 	}

--- a/claat/main.go
+++ b/claat/main.go
@@ -70,9 +70,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	passMeta := make(map[string]bool)
+	passMetadata := make(map[string]bool)
 	for _, v := range strings.Split(*pass_metadata, ",") {
-		passMeta[v] = true
+		passMetadata[v] = true
 	}
 
 	exitCode := 0
@@ -84,7 +84,7 @@ func main() {
 			ExtraVars:    extraVars,
 			GlobalGA:     *globalGA,
 			Output:       *output,
-			PassMetadata: passMeta,
+			PassMetadata: passMetadata,
 			Prefix:       *prefix,
 			Srcs:         flag.Args(),
 			Tmplout:      *tmplout,
@@ -96,7 +96,7 @@ func main() {
 			AuthToken:    *authToken,
 			ExtraVars:    extraVars,
 			GlobalGA:     *globalGA,
-			PassMetadata: passMeta,
+			PassMetadata: passMetadata,
 			Prefix:       *prefix,
 		})
 	case "help":

--- a/claat/main.go
+++ b/claat/main.go
@@ -72,7 +72,7 @@ func main() {
 
 	pm := make(map[string]bool)
 	for _, v := range strings.Split(*passMetadata, ",") {
-		pm[v] = true
+		pm[strings.ToLower(v)] = true
 	}
 
 	exitCode := 0

--- a/claat/main.go
+++ b/claat/main.go
@@ -26,6 +26,7 @@ import (
 	"log"
 	"math/rand"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/googlecodelabs/tools/claat/cmd"
@@ -69,27 +70,34 @@ func main() {
 		os.Exit(1)
 	}
 
+	passMeta := make(map[string]bool)
+	for _, v := range strings.Split(*pass_metadata, ",") {
+		passMeta[v] = true
+	}
+
 	exitCode := 0
 	switch os.Args[1] {
 	case "export":
 		exitCode = cmd.CmdExport(cmd.CmdExportOptions{
-			AuthToken: *authToken,
-			Expenv:    *expenv,
-			ExtraVars: extraVars,
-			GlobalGA:  *globalGA,
-			Output:    *output,
-			Prefix:    *prefix,
-			Srcs:      flag.Args(),
-			Tmplout:   *tmplout,
+			AuthToken:    *authToken,
+			Expenv:       *expenv,
+			ExtraVars:    extraVars,
+			GlobalGA:     *globalGA,
+			Output:       *output,
+			PassMetadata: passMeta,
+			Prefix:       *prefix,
+			Srcs:         flag.Args(),
+			Tmplout:      *tmplout,
 		})
 	case "serve":
 		exitCode = cmd.CmdServe(*addr)
 	case "update":
 		exitCode = cmd.CmdUpdate(cmd.CmdUpdateOptions{
-			AuthToken: *authToken,
-			ExtraVars: extraVars,
-			GlobalGA:  *globalGA,
-			Prefix:    *prefix,
+			AuthToken:    *authToken,
+			ExtraVars:    extraVars,
+			GlobalGA:     *globalGA,
+			PassMetadata: passMeta,
+			Prefix:       *prefix,
 		})
 	case "help":
 		usage()

--- a/claat/main.go
+++ b/claat/main.go
@@ -40,15 +40,15 @@ var (
 	version string // set by linker -X
 
 	// Flags.
-	addr          = flag.String("addr", "localhost:9090", "hostname and port to bind web server to")
-	authToken     = flag.String("auth", "", "OAuth2 Bearer token; alternative credentials override.")
-	expenv        = flag.String("e", "web", "codelab environment")
-	extra         = flag.String("extra", "", "Additional arguments to pass to format templates. JSON object of string,string key values.")
-	globalGA      = flag.String("ga", "UA-49880327-14", "global Google Analytics account")
-	output        = flag.String("o", ".", "output directory or '-' for stdout")
-	pass_metadata = flag.String("pass_metadata", "", "Metadata fields to pass through to the output. Comma-delimited list of field names.")
-	prefix        = flag.String("prefix", "https://storage.googleapis.com", "URL prefix for html format")
-	tmplout       = flag.String("f", "html", "output format")
+	addr         = flag.String("addr", "localhost:9090", "hostname and port to bind web server to")
+	authToken    = flag.String("auth", "", "OAuth2 Bearer token; alternative credentials override.")
+	expenv       = flag.String("e", "web", "codelab environment")
+	extra        = flag.String("extra", "", "Additional arguments to pass to format templates. JSON object of string,string key values.")
+	globalGA     = flag.String("ga", "UA-49880327-14", "global Google Analytics account")
+	output       = flag.String("o", ".", "output directory or '-' for stdout")
+	passMetadata = flag.String("pass_metadata", "", "Metadata fields to pass through to the output. Comma-delimited list of field names.")
+	prefix       = flag.String("prefix", "https://storage.googleapis.com", "URL prefix for html format")
+	tmplout      = flag.String("f", "html", "output format")
 )
 
 func main() {
@@ -70,9 +70,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	passMetadata := make(map[string]bool)
-	for _, v := range strings.Split(*pass_metadata, ",") {
-		passMetadata[v] = true
+	pm := make(map[string]bool)
+	for _, v := range strings.Split(*passMetadata, ",") {
+		pm[v] = true
 	}
 
 	exitCode := 0
@@ -84,7 +84,7 @@ func main() {
 			ExtraVars:    extraVars,
 			GlobalGA:     *globalGA,
 			Output:       *output,
-			PassMetadata: passMetadata,
+			PassMetadata: pm,
 			Prefix:       *prefix,
 			Srcs:         flag.Args(),
 			Tmplout:      *tmplout,
@@ -96,7 +96,7 @@ func main() {
 			AuthToken:    *authToken,
 			ExtraVars:    extraVars,
 			GlobalGA:     *globalGA,
-			PassMetadata: passMetadata,
+			PassMetadata: pm,
 			Prefix:       *prefix,
 		})
 	case "help":

--- a/claat/main.go
+++ b/claat/main.go
@@ -110,7 +110,7 @@ func main() {
 // parsePassMetadata parses metadata fields to parse that are not explicitly handled elsewhere.
 // It expects the fields to be passed in as a comma separated list (extraneous spaces are autoremoved), and returns a set of strings.
 func parsePassMetadata(passMeta string) map[string]bool {
-	fields := make(map[string]bool)
+	fields := map[string]bool{}
 	for _, v := range strings.Split(passMeta, ",") {
 		fields[strings.ToLower(strings.TrimSpace(v))] = true
 	}

--- a/claat/main.go
+++ b/claat/main.go
@@ -39,14 +39,15 @@ var (
 	version string // set by linker -X
 
 	// Flags.
-	addr      = flag.String("addr", "localhost:9090", "hostname and port to bind web server to")
-	authToken = flag.String("auth", "", "OAuth2 Bearer token; alternative credentials override.")
-	expenv    = flag.String("e", "web", "codelab environment")
-	extra     = flag.String("extra", "", "Additional arguments to pass to format templates. JSON object of string,string key values.")
-	globalGA  = flag.String("ga", "UA-49880327-14", "global Google Analytics account")
-	output    = flag.String("o", ".", "output directory or '-' for stdout")
-	prefix    = flag.String("prefix", "https://storage.googleapis.com", "URL prefix for html format")
-	tmplout   = flag.String("f", "html", "output format")
+	addr          = flag.String("addr", "localhost:9090", "hostname and port to bind web server to")
+	authToken     = flag.String("auth", "", "OAuth2 Bearer token; alternative credentials override.")
+	expenv        = flag.String("e", "web", "codelab environment")
+	extra         = flag.String("extra", "", "Additional arguments to pass to format templates. JSON object of string,string key values.")
+	globalGA      = flag.String("ga", "UA-49880327-14", "global Google Analytics account")
+	output        = flag.String("o", ".", "output directory or '-' for stdout")
+	pass_metadata = flag.String("pass_metadata", "", "Metadata fields to pass through to the output. Comma-delimited list of field names.")
+	prefix        = flag.String("prefix", "https://storage.googleapis.com", "URL prefix for html format")
+	tmplout       = flag.String("f", "html", "output format")
 )
 
 func main() {

--- a/claat/main.go
+++ b/claat/main.go
@@ -70,10 +70,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	pm := make(map[string]bool)
-	for _, v := range strings.Split(*passMetadata, ",") {
-		pm[strings.ToLower(strings.TrimSpace(v))] = true
-	}
+	pm := parsePassMetadata(*passMetadata)
 
 	exitCode := 0
 	switch os.Args[1] {
@@ -108,6 +105,16 @@ func main() {
 	}
 
 	os.Exit(exitCode)
+}
+
+// parsePassMetadata parses metadata fields to parse that are not explicitly handled elsewhere.
+// It expects the fields to be passed in as a comma separated list (extraneous spaces are autoremoved), and returns a set of strings.
+func parsePassMetadata(passMeta string) map[string]bool {
+	fields := make(map[string]bool)
+	for _, v := range strings.Split(passMeta, ",") {
+		fields[strings.ToLower(strings.TrimSpace(v))] = true
+	}
+	return fields
 }
 
 // ParseExtraVars parses extra template variables from command line.

--- a/claat/main.go
+++ b/claat/main.go
@@ -72,7 +72,7 @@ func main() {
 
 	pm := make(map[string]bool)
 	for _, v := range strings.Split(*passMetadata, ",") {
-		pm[strings.ToLower(v)] = true
+		pm[strings.ToLower(strings.TrimSpace(v))] = true
 	}
 
 	exitCode := 0

--- a/claat/parser/gdoc/parse.go
+++ b/claat/parser/gdoc/parse.go
@@ -206,7 +206,7 @@ func parseDoc(doc *html.Node, opts parser.Options) (*types.Codelab, error) {
 
 	ds := newDocState()
 	ds.css = style
-	ds.passMetadata = opts.passMetadata
+	ds.passMetadata = opts.PassMetadata
 
 	for ds.cur = body.FirstChild; ds.cur != nil; ds.cur = ds.cur.NextSibling {
 		if isComment(ds.css, ds.cur) {

--- a/claat/parser/gdoc/parse.go
+++ b/claat/parser/gdoc/parse.go
@@ -206,6 +206,7 @@ func parseDoc(doc *html.Node, opts parser.Options) (*types.Codelab, error) {
 
 	ds := newDocState()
 	ds.css = style
+	ds.passMetadata = opts.passMetadata
 
 	for ds.cur = body.FirstChild; ds.cur != nil; ds.cur = ds.cur.NextSibling {
 		if isComment(ds.css, ds.cur) {

--- a/claat/parser/gdoc/parse.go
+++ b/claat/parser/gdoc/parse.go
@@ -411,6 +411,7 @@ func metaTable(ds *docState) {
 		case "analytics", "analytics account", "google analytics":
 			ds.clab.GA = s
 		default:
+			// If not explicitly parsed, it might be a pass_metadata value.
 			if _, ok := ds.passMetadata[fieldName]; ok {
 				ds.clab.Extra[fieldName] = s
 			}

--- a/claat/parser/gdoc/parse.go
+++ b/claat/parser/gdoc/parse.go
@@ -128,6 +128,13 @@ type stackItem struct {
 	flags stateFlag
 }
 
+func newDocState() *docState {
+	ds := new(docState)
+	ds.clab = types.NewCodelab()
+
+	return ds
+}
+
 func (ds *docState) push(cur *html.Node, flags stateFlag) {
 	if cur == nil {
 		cur = ds.cur
@@ -170,10 +177,9 @@ func parseFragment(doc *html.Node) ([]types.Node, error) {
 	if err != nil {
 		return nil, err
 	}
-	ds := &docState{
-		clab: &types.Codelab{},
-		css:  style,
-	}
+
+	ds := newDocState()
+	ds.css = style
 	ds.step = ds.clab.NewStep("fragment")
 	for ds.cur = body.FirstChild; ds.cur != nil; ds.cur = ds.cur.NextSibling {
 		if isComment(ds.css, ds.cur) {
@@ -198,10 +204,9 @@ func parseDoc(doc *html.Node) (*types.Codelab, error) {
 		return nil, err
 	}
 
-	ds := &docState{
-		clab: &types.Codelab{},
-		css:  style,
-	}
+	ds := newDocState()
+	ds.css = style
+
 	for ds.cur = body.FirstChild; ds.cur != nil; ds.cur = ds.cur.NextSibling {
 		if isComment(ds.css, ds.cur) {
 			// docs export comments at the end of the body

--- a/claat/parser/gdoc/parse.go
+++ b/claat/parser/gdoc/parse.go
@@ -42,7 +42,7 @@ type Parser struct {
 }
 
 // Parse parses a codelab exported in HTML from Google Docs.
-func (p *Parser) Parse(r io.Reader) (*types.Codelab, error) {
+func (p *Parser) Parse(r io.Reader, opts parser.Options) (*types.Codelab, error) {
 	// TODO: use html.Tokenizer instead
 	doc, err := html.Parse(r)
 	if err != nil {

--- a/claat/parser/gdoc/parse.go
+++ b/claat/parser/gdoc/parse.go
@@ -129,8 +129,9 @@ type stackItem struct {
 }
 
 func newDocState() *docState {
-	ds := new(docState)
-	ds.clab = types.NewCodelab()
+	ds := &docState{
+		clab: types.NewCodelab(),
+	}
 
 	return ds
 }

--- a/claat/parser/gdoc/parse.go
+++ b/claat/parser/gdoc/parse.go
@@ -110,17 +110,17 @@ const (
 )
 
 type docState struct {
-	clab     *types.Codelab  // codelab and its metadata
-	totdur   time.Duration   // total codelab duration
-	survey   int             // last used survey ID
-	css      cssStyle        // styles of the doc
-	step     *types.Step     // current codelab step
-	lastNode types.Node      // last appended node
-	env      []string        // current enviornment
-	cur      *html.Node      // current HTML node
-	flags    stateFlag       // current flags
-	stack    []*stackItem    // cur and flags stack
-	passMeta map[string]bool // set of metadata fields to pass along.
+	clab         *types.Codelab  // codelab and its metadata
+	totdur       time.Duration   // total codelab duration
+	survey       int             // last used survey ID
+	css          cssStyle        // styles of the doc
+	step         *types.Step     // current codelab step
+	lastNode     types.Node      // last appended node
+	env          []string        // current enviornment
+	cur          *html.Node      // current HTML node
+	flags        stateFlag       // current flags
+	stack        []*stackItem    // cur and flags stack
+	passMetadata map[string]bool // set of metadata fields to pass along.
 }
 
 type stackItem struct {
@@ -404,7 +404,7 @@ func metaTable(ds *docState) {
 		case "analytics", "analytics account", "google analytics":
 			ds.clab.GA = s
 		default:
-			if _, ok := ds.passMeta[fieldName]; ok {
+			if _, ok := ds.passMetadata[fieldName]; ok {
 				ds.clab.Extra[fieldName] = s
 			}
 		}

--- a/claat/parser/gdoc/parse.go
+++ b/claat/parser/gdoc/parse.go
@@ -48,7 +48,7 @@ func (p *Parser) Parse(r io.Reader, opts parser.Options) (*types.Codelab, error)
 	if err != nil {
 		return nil, err
 	}
-	return parseDoc(doc)
+	return parseDoc(doc, opts)
 }
 
 // ParseFragment parses a codelab fragment exported in HTML from Google Docs.
@@ -194,7 +194,7 @@ func parseFragment(doc *html.Node) ([]types.Node, error) {
 
 // parseDoc parses codelab doc exported as text/html.
 // The doc must contain CSS styles and <body> as exported from Google Doc.
-func parseDoc(doc *html.Node) (*types.Codelab, error) {
+func parseDoc(doc *html.Node, opts parser.Options) (*types.Codelab, error) {
 	body := findAtom(doc, atom.Body)
 	if body == nil {
 		return nil, fmt.Errorf("document without a body")

--- a/claat/parser/gdoc/parse_test.go
+++ b/claat/parser/gdoc/parse_test.go
@@ -175,7 +175,7 @@ func TestMetaTable(t *testing.T) {
 	`
 
 	p := &Parser{}
-	clab, err := p.Parse(markupReader(markup), parser.Options{})
+	clab, err := p.Parse(markupReader(markup), *parser.NewOptions())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -251,11 +251,12 @@ func TestMetaTablePassMetadata(t *testing.T) {
 	`
 
 	p := &Parser{}
-	clab, err := p.Parse(markupReader(markup), parser.Options{
-		PassMetadata: map[string]bool{
-			"extrafieldone": true,
-		},
-	})
+	opts := *parser.NewOptions()
+	opts.PassMetadata = map[string]bool{
+		"extrafieldone": true,
+	}
+
+	clab, err := p.Parse(markupReader(markup), opts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -377,7 +378,7 @@ func TestParseDoc(t *testing.T) {
 	`
 
 	p := &Parser{}
-	c, err := p.Parse(markupReader(markup), parser.Options{})
+	c, err := p.Parse(markupReader(markup), *parser.NewOptions())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/claat/parser/gdoc/parse_test.go
+++ b/claat/parser/gdoc/parse_test.go
@@ -204,6 +204,88 @@ func TestMetaTable(t *testing.T) {
 	}
 }
 
+func TestMetaTablePassMetadata(t *testing.T) {
+	const markup = `
+	<html>
+	<body>
+		<table>
+			<tr>
+				<td>Summary</td>
+				<td>Test summary</td>
+			</tr>
+			<tr>
+				<td>Authors</td>
+				<td>John Smith &lt;user@example.com&gt;</td>
+			</tr>
+			<tr>
+				<td>Category</td>
+				<td>Foo, Bar</td>
+			</tr>
+			<tr>
+				<td>Environment</td>
+				<td>Web, Kiosk</td>
+			</tr>
+			<tr>
+				<td>Status</td>
+				<td>Final</td>
+			</tr>
+			<tr>
+				<td>Feedback</td>
+				<td>https://example.com/issues</td>
+			</tr>
+			<tr>
+				<td>Analytics</td>
+				<td>GA-12345</td>
+			</tr>
+			<tr>
+				<td>ExtraFieldOne</td>
+				<td>11111</td>
+			</tr>
+			<tr>
+				<td>ExtraFieldTwo</td>
+				<td>22222</td>
+			</tr>
+		</table>
+	</body>
+	</html>
+	`
+
+	p := &Parser{}
+	clab, err := p.Parse(markupReader(markup), parser.Options{
+		PassMetadata: map[string]bool{
+			"extrafieldone": true,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	meta := types.Meta{
+		Summary:    "Test summary",
+		Authors:    "John Smith <user@example.com>",
+		Categories: []string{"Foo", "Bar"},
+		Theme:      "foo",
+		Status:     clab.Meta.Status, // verified separately
+		Feedback:   "https://example.com/issues",
+		GA:         "GA-12345",
+		// Tags are always sorted.
+		// TODO: move sorting to Parse of the parser package
+		Tags: []string{"kiosk", "web"},
+		Extra: map[string]string{
+			"extrafieldone": "11111",
+		},
+	}
+	if !reflect.DeepEqual(clab.Meta, meta) {
+		t.Errorf("Meta: \n%+v\nwant:\n%+v", clab.Meta, meta)
+	}
+	status := types.LegacyStatus([]string{"final"})
+	if clab.Meta.Status == nil {
+		t.Fatalf("Meta.Status is nil; want %q", status)
+	}
+	if !reflect.DeepEqual(clab.Meta.Status, &status) {
+		t.Errorf("Meta.Status: %q; want %q", *clab.Meta.Status, status)
+	}
+}
+
 func TestParseDoc(t *testing.T) {
 	const markup = `
 	<html><head><style>

--- a/claat/parser/gdoc/parse_test.go
+++ b/claat/parser/gdoc/parse_test.go
@@ -24,6 +24,7 @@ import (
 
 	"golang.org/x/net/html"
 
+	"github.com/googlecodelabs/tools/claat/parser"
 	"github.com/googlecodelabs/tools/claat/render"
 	"github.com/googlecodelabs/tools/claat/types"
 )
@@ -174,7 +175,7 @@ func TestMetaTable(t *testing.T) {
 	`
 
 	p := &Parser{}
-	clab, err := p.Parse(markupReader(markup))
+	clab, err := p.Parse(markupReader(markup), parser.Options{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -188,7 +189,8 @@ func TestMetaTable(t *testing.T) {
 		GA:         "GA-12345",
 		// Tags are always sorted.
 		// TODO: move sorting to Parse of the parser package
-		Tags: []string{"kiosk", "web"},
+		Tags:  []string{"kiosk", "web"},
+		Extra: map[string]string{},
 	}
 	if !reflect.DeepEqual(clab.Meta, meta) {
 		t.Errorf("Meta: \n%+v\nwant:\n%+v", clab.Meta, meta)
@@ -293,7 +295,7 @@ func TestParseDoc(t *testing.T) {
 	`
 
 	p := &Parser{}
-	c, err := p.Parse(markupReader(markup))
+	c, err := p.Parse(markupReader(markup), parser.Options{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/claat/parser/md/parse.go
+++ b/claat/parser/md/parse.go
@@ -91,7 +91,7 @@ type Parser struct {
 }
 
 // Parse parses a codelab written in Markdown.
-func (p *Parser) Parse(r io.Reader) (*types.Codelab, error) {
+func (p *Parser) Parse(r io.Reader, opts parser.Options) (*types.Codelab, error) {
 	// Convert Markdown to HTML for easy parsing.
 	b, err := ioutil.ReadAll(r)
 	if err != nil {
@@ -639,26 +639,26 @@ func list(ds *docState) types.Node {
 // It returns nil if src is empty.
 // It may also return a YouTubeNode if alt property contains specific substring.
 func image(ds *docState) types.Node {
-        alt := nodeAttr(ds.cur, "alt")
-        if strings.Contains(alt, "youtube.com/watch") {
-                return youtube(ds)
-        } else if strings.Contains(alt, "https://") {
-                u, err := url.Parse(nodeAttr(ds.cur, "alt"))
-                if err != nil {
-                        return nil
-                }
-                // For iframe, make sure URL ends in whitelisted domain.
-                ok := false
-                for _, domain := range types.IframeWhitelist {
-                        if strings.HasSuffix(u.Hostname(), domain) {
-                                ok = true
-                                break
-                        }
-                }
-                if ok {
-                        return iframe(ds)
-                }
-        }
+	alt := nodeAttr(ds.cur, "alt")
+	if strings.Contains(alt, "youtube.com/watch") {
+		return youtube(ds)
+	} else if strings.Contains(alt, "https://") {
+		u, err := url.Parse(nodeAttr(ds.cur, "alt"))
+		if err != nil {
+			return nil
+		}
+		// For iframe, make sure URL ends in whitelisted domain.
+		ok := false
+		for _, domain := range types.IframeWhitelist {
+			if strings.HasSuffix(u.Hostname(), domain) {
+				ok = true
+				break
+			}
+		}
+		if ok {
+			return iframe(ds)
+		}
+	}
 	s := nodeAttr(ds.cur, "src")
 	if s == "" {
 		return nil
@@ -701,17 +701,17 @@ func youtube(ds *docState) types.Node {
 }
 
 func iframe(ds *docState) types.Node {
-        u, err := url.Parse(nodeAttr(ds.cur, "alt"))
-        if err != nil {
-                return nil
-        }
-        // Allow only https.
-        if u.Scheme != "https" {
-                return nil
-        }
-        n := types.NewIframeNode(u.String())
-        n.MutateBlock(true)
-        return n
+	u, err := url.Parse(nodeAttr(ds.cur, "alt"))
+	if err != nil {
+		return nil
+	}
+	// Allow only https.
+	if u.Scheme != "https" {
+		return nil
+	}
+	n := types.NewIframeNode(u.String())
+	n.MutateBlock(true)
+	return n
 }
 
 // button returns either a text node, if no <a> child element is present,

--- a/claat/parser/md/parse.go
+++ b/claat/parser/md/parse.go
@@ -128,8 +128,9 @@ type stackItem struct {
 }
 
 func newDocState() *docState {
-	ds := new(docState)
-	ds.clab = types.NewCodelab()
+	ds := &docState{
+		clab: types.NewCodelab(),
+	}
 
 	return ds
 }

--- a/claat/parser/md/parse.go
+++ b/claat/parser/md/parse.go
@@ -128,11 +128,9 @@ type stackItem struct {
 }
 
 func newDocState() *docState {
-	ds := &docState{
+	return &docState{
 		clab: types.NewCodelab(),
 	}
-
-	return ds
 }
 
 func (ds *docState) push(cur *html.Node) {

--- a/claat/parser/md/parse_test.go
+++ b/claat/parser/md/parse_test.go
@@ -35,8 +35,8 @@ const stdHeader = stdMeta + `
 # Codelab Title
 `
 
-func mustParseCodelab(markup string) *types.Codelab {
-	c, err := parseCodelab(markup)
+func mustParseCodelab(markup string, opts parser.Options) *types.Codelab {
+	c, err := parseCodelab(markup, opts)
 	if err != nil {
 		log.Fatalf("Error parsing markup %v: %v", markup, err)
 	}
@@ -44,17 +44,17 @@ func mustParseCodelab(markup string) *types.Codelab {
 	return c
 }
 
-func parseCodelab(markup string) (*types.Codelab, error) {
+func parseCodelab(markup string, opts parser.Options) (*types.Codelab, error) {
 	r := strings.NewReader(markup)
 	p := &Parser{}
 
-	return p.Parse(r, parser.Options{})
+	return p.Parse(r, opts)
 }
 
 func TestHandleCodelabTitle(t *testing.T) {
 	// Set up.
 	title := "Egret"
-	c := mustParseCodelab(fmt.Sprintf("# %s", title))
+	c := mustParseCodelab(fmt.Sprintf("# %s", title), parser.Options{})
 
 	if c.Title != title {
 		t.Errorf("[%q] got %v, want %v", title, c.Title, title)
@@ -90,7 +90,7 @@ func TestProcessDuration(t *testing.T) {
 
 	for i, tc := range tests {
 		content := fmt.Sprintf(stdHeader+"\n## Step Title\nDuration: %v\n", tc.in)
-		c := mustParseCodelab(content)
+		c := mustParseCodelab(content, parser.Options{})
 		out := time.Duration(c.Duration) * time.Minute
 
 		if out != tc.out {
@@ -120,7 +120,7 @@ Duration: %v
 			content += fmt.Sprintf(tmp, dur)
 		}
 
-		c := mustParseCodelab(content)
+		c := mustParseCodelab(content, parser.Options{})
 		if c.Duration != tc.out {
 			t.Errorf("%d: wanted duration %d but got %d", i, c.Duration, tc.out)
 		}
@@ -154,7 +154,48 @@ feedback link: https://www.google.com
 `
 	content += ("# " + title)
 
-	c := mustParseCodelab(content)
+	c := mustParseCodelab(content, parser.Options{})
+	if !reflect.DeepEqual(c.Meta, wantMeta) {
+		t.Errorf("\ngot:\n%+v\nwant:\n%+v", c.Meta, wantMeta)
+	}
+}
+
+func TestParseMetadataPassMetadata(t *testing.T) {
+	title := "Codelab Title"
+	wantMeta := types.Meta{
+		Title:      title,
+		ID:         "zyxwvut",
+		Authors:    "john smith",
+		Summary:    "abcdefghij",
+		Categories: []string{"not", "really"},
+		Tags:       []string{"kiosk", "web"},
+		Feedback:   "https://www.google.com",
+		GA:         "12345",
+		Extra: map[string]string{
+			"extrafieldtwo": "bbbbb",
+		},
+	}
+
+	content := `---
+id: zyxwvut
+authors: john smith
+summary: abcdefghij
+categories: not, really
+environments: kiosk, web
+analytics account: 12345
+feedback link: https://www.google.com
+extrafieldone: aaaaa
+extrafieldtwo: bbbbb
+
+---
+`
+	content += ("# " + title)
+
+	c := mustParseCodelab(content, parser.Options{
+		PassMetadata: map[string]bool{
+			"extrafieldtwo": true,
+		},
+	})
 	if !reflect.DeepEqual(c.Meta, wantMeta) {
 		t.Errorf("\ngot:\n%+v\nwant:\n%+v", c.Meta, wantMeta)
 	}

--- a/claat/parser/md/parse_test.go
+++ b/claat/parser/md/parse_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/googlecodelabs/tools/claat/parser"
 	"github.com/googlecodelabs/tools/claat/types"
 )
 
@@ -47,7 +48,7 @@ func parseCodelab(markup string) (*types.Codelab, error) {
 	r := strings.NewReader(markup)
 	p := &Parser{}
 
-	return p.Parse(r)
+	return p.Parse(r, parser.Options{})
 }
 
 func TestHandleCodelabTitle(t *testing.T) {
@@ -137,6 +138,7 @@ func TestParseMetadata(t *testing.T) {
 		Tags:       []string{"kiosk", "web"},
 		Feedback:   "https://www.google.com",
 		GA:         "12345",
+		Extra:      map[string]string{},
 	}
 
 	content := `---

--- a/claat/parser/md/parse_test.go
+++ b/claat/parser/md/parse_test.go
@@ -54,7 +54,7 @@ func parseCodelab(markup string, opts parser.Options) (*types.Codelab, error) {
 func TestHandleCodelabTitle(t *testing.T) {
 	// Set up.
 	title := "Egret"
-	c := mustParseCodelab(fmt.Sprintf("# %s", title), parser.Options{})
+	c := mustParseCodelab(fmt.Sprintf("# %s", title), *parser.NewOptions())
 
 	if c.Title != title {
 		t.Errorf("[%q] got %v, want %v", title, c.Title, title)
@@ -90,7 +90,7 @@ func TestProcessDuration(t *testing.T) {
 
 	for i, tc := range tests {
 		content := fmt.Sprintf(stdHeader+"\n## Step Title\nDuration: %v\n", tc.in)
-		c := mustParseCodelab(content, parser.Options{})
+		c := mustParseCodelab(content, *parser.NewOptions())
 		out := time.Duration(c.Duration) * time.Minute
 
 		if out != tc.out {
@@ -120,7 +120,7 @@ Duration: %v
 			content += fmt.Sprintf(tmp, dur)
 		}
 
-		c := mustParseCodelab(content, parser.Options{})
+		c := mustParseCodelab(content, *parser.NewOptions())
 		if c.Duration != tc.out {
 			t.Errorf("%d: wanted duration %d but got %d", i, c.Duration, tc.out)
 		}
@@ -154,7 +154,7 @@ feedback link: https://www.google.com
 `
 	content += ("# " + title)
 
-	c := mustParseCodelab(content, parser.Options{})
+	c := mustParseCodelab(content, *parser.NewOptions())
 	if !reflect.DeepEqual(c.Meta, wantMeta) {
 		t.Errorf("\ngot:\n%+v\nwant:\n%+v", c.Meta, wantMeta)
 	}
@@ -191,11 +191,12 @@ extrafieldtwo: bbbbb
 `
 	content += ("# " + title)
 
-	c := mustParseCodelab(content, parser.Options{
-		PassMetadata: map[string]bool{
-			"extrafieldtwo": true,
-		},
-	})
+	opts := *parser.NewOptions()
+	opts.PassMetadata = map[string]bool{
+		"extrafieldtwo": true,
+	}
+
+	c := mustParseCodelab(content, opts)
 	if !reflect.DeepEqual(c.Meta, wantMeta) {
 		t.Errorf("\ngot:\n%+v\nwant:\n%+v", c.Meta, wantMeta)
 	}

--- a/claat/parser/parse.go
+++ b/claat/parser/parse.go
@@ -32,7 +32,10 @@ type Parser interface {
 	ParseFragment(r io.Reader) ([]types.Node, error)
 }
 
-type Options struct{}
+// Container for parsing options.
+type Options struct {
+	PassMetadata map[string]bool
+}
 
 var (
 	parsersMu sync.Mutex // guards parsers

--- a/claat/parser/parse.go
+++ b/claat/parser/parse.go
@@ -26,11 +26,13 @@ import (
 // Each parser needs to call Register to become a known parser.
 type Parser interface {
 	// Parse parses source r into a Codelab for the specified environment env.
-	Parse(r io.Reader) (*types.Codelab, error)
+	Parse(r io.Reader, opts Options) (*types.Codelab, error)
 
 	// ParseFragment is similar to Parse except it doesn't parse codelab metadata.
 	ParseFragment(r io.Reader) ([]types.Node, error)
 }
+
+type Options struct{}
 
 var (
 	parsersMu sync.Mutex // guards parsers
@@ -61,14 +63,14 @@ func Parsers() []string {
 
 // Parse parses source r into a Codelab using a parser registered with
 // the specified name.
-func Parse(name string, r io.Reader) (*types.Codelab, error) {
+func Parse(name string, r io.Reader, opts Options) (*types.Codelab, error) {
 	parsersMu.Lock()
 	p, ok := parsers[name]
 	parsersMu.Unlock()
 	if !ok {
 		return nil, fmt.Errorf("no parser named %q", name)
 	}
-	c, err := p.Parse(r)
+	c, err := p.Parse(r, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/claat/parser/parse.go
+++ b/claat/parser/parse.go
@@ -37,6 +37,12 @@ type Options struct {
 	PassMetadata map[string]bool
 }
 
+func NewOptions() *Options {
+	return &Options{
+		PassMetadata: map[string]bool{},
+	}
+}
+
 var (
 	parsersMu sync.Mutex // guards parsers
 	parsers   = make(map[string]Parser)

--- a/claat/types/meta.go
+++ b/claat/types/meta.go
@@ -67,7 +67,7 @@ type Codelab struct {
 
 func NewCodelab() *Codelab {
 	clab := &Codelab{}
-	clab.Extra = make(map[string]string)
+	clab.Extra = map[string]string{}
 
 	return clab
 }

--- a/claat/types/meta.go
+++ b/claat/types/meta.go
@@ -66,8 +66,9 @@ type Codelab struct {
 }
 
 func NewCodelab() *Codelab {
-	clab := new(Codelab)
+	clab := &Codelab{}
 	clab.Extra = make(map[string]string)
+
 	return clab
 }
 

--- a/claat/types/meta.go
+++ b/claat/types/meta.go
@@ -25,19 +25,20 @@ import (
 
 // Meta contains a single codelab metadata.
 type Meta struct {
-	ID         string        `json:"id"`                 // ID is also part of codelab URL
-	Duration   int           `json:"duration"`           // Codelab duration in minutes
-	Title      string        `json:"title"`              // Codelab title
-	Authors    string        `json:"authors,omitempty"`  // Arbitrary authorship text
-	BadgeID    string        `json:"badge_id,omitempty"` // ID of the BAdge to grant on codelab completion on devsite
-	Summary    string        `json:"summary"`            // Short summary
-	Source     string        `json:"source"`             // Codelab source doc
-	Theme      string        `json:"theme"`              // Usually first item of Categories
-	Status     *LegacyStatus `json:"status"`             // Draft, Published, Hidden, etc.
-	Categories []string      `json:"category"`           // Categories from the meta table
-	Tags       []string      `json:"tags"`               // All environments supported by the codelab
-	Feedback   string        `json:"feedback,omitempty"` // Issues and bugs are sent here
-	GA         string        `json:"ga,omitempty"`       // Codelab-specific GA tracking ID
+	ID         string            `json:"id"`                 // ID is also part of codelab URL
+	Duration   int               `json:"duration"`           // Codelab duration in minutes
+	Title      string            `json:"title"`              // Codelab title
+	Authors    string            `json:"authors,omitempty"`  // Arbitrary authorship text
+	BadgeID    string            `json:"badge_id,omitempty"` // ID of the BAdge to grant on codelab completion on devsite
+	Summary    string            `json:"summary"`            // Short summary
+	Source     string            `json:"source"`             // Codelab source doc
+	Theme      string            `json:"theme"`              // Usually first item of Categories
+	Status     *LegacyStatus     `json:"status"`             // Draft, Published, Hidden, etc.
+	Categories []string          `json:"category"`           // Categories from the meta table
+	Tags       []string          `json:"tags"`               // All environments supported by the codelab
+	Feedback   string            `json:"feedback,omitempty"` // Issues and bugs are sent here
+	GA         string            `json:"ga,omitempty"`       // Codelab-specific GA tracking ID
+	Extra      map[string]string `json:"extra"`              // Extra metadata specified in pass_metadata
 
 	URL string `json:"url"` // Legacy ID; TODO: remove
 }
@@ -45,11 +46,12 @@ type Meta struct {
 // Context is an export context.
 // It is defined in this package so that it can be used by both cli and a server.
 type Context struct {
-	Env     string       `json:"environment"`       // Current export environment
-	Format  string       `json:"format"`            // Output format, e.g. "html"
-	Prefix  string       `json:"prefix,omitempty"`  // Assets URL prefix for HTML-based formats
-	MainGA  string       `json:"mainga,omitempty"`  // Global Google Analytics ID
-	Updated *ContextTime `json:"updated,omitempty"` // Last update timestamp
+	Env          string          `json:"environment"` // Current export environment
+	Format       string          `json:"format"`      // Output format, e.g. "html"
+	PassMetadata map[string]bool // PassMetadata are the extra metadata fields to pass along.
+	Prefix       string          `json:"prefix,omitempty"`  // Assets URL prefix for HTML-based formats
+	MainGA       string          `json:"mainga,omitempty"`  // Global Google Analytics ID
+	Updated      *ContextTime    `json:"updated,omitempty"` // Last update timestamp
 }
 
 // ContextMeta is a composition of export context and meta data.

--- a/claat/types/meta.go
+++ b/claat/types/meta.go
@@ -38,7 +38,7 @@ type Meta struct {
 	Tags       []string          `json:"tags"`               // All environments supported by the codelab
 	Feedback   string            `json:"feedback,omitempty"` // Issues and bugs are sent here
 	GA         string            `json:"ga,omitempty"`       // Codelab-specific GA tracking ID
-	Extra      map[string]string `json:"extra"`              // Extra metadata specified in pass_metadata
+	Extra      map[string]string `json:"extra,omitempty"`    // Extra metadata specified in pass_metadata
 
 	URL string `json:"url"` // Legacy ID; TODO: remove
 }

--- a/claat/types/meta.go
+++ b/claat/types/meta.go
@@ -66,6 +66,12 @@ type Codelab struct {
 	Steps []*Step
 }
 
+func NewCodelab() *Codelab {
+	clab := new(Codelab)
+	clab.Extra = make(map[string]string)
+	return clab
+}
+
 // NewStep creates a new codelab step, adding it to c.Steps slice.
 func (c *Codelab) NewStep(title string) *Step {
 	s := &Step{Title: title, Content: NewListNode()}

--- a/claat/types/meta.go
+++ b/claat/types/meta.go
@@ -46,12 +46,11 @@ type Meta struct {
 // Context is an export context.
 // It is defined in this package so that it can be used by both cli and a server.
 type Context struct {
-	Env          string          `json:"environment"` // Current export environment
-	Format       string          `json:"format"`      // Output format, e.g. "html"
-	PassMetadata map[string]bool // PassMetadata are the extra metadata fields to pass along.
-	Prefix       string          `json:"prefix,omitempty"`  // Assets URL prefix for HTML-based formats
-	MainGA       string          `json:"mainga,omitempty"`  // Global Google Analytics ID
-	Updated      *ContextTime    `json:"updated,omitempty"` // Last update timestamp
+	Env     string       `json:"environment"`       // Current export environment
+	Format  string       `json:"format"`            // Output format, e.g. "html"
+	Prefix  string       `json:"prefix,omitempty"`  // Assets URL prefix for HTML-based formats
+	MainGA  string       `json:"mainga,omitempty"`  // Global Google Analytics ID
+	Updated *ContextTime `json:"updated,omitempty"` // Last update timestamp
 }
 
 // ContextMeta is a composition of export context and meta data.


### PR DESCRIPTION
Implements a new command line flag, pass_metadata, that allows you to specify additional metadata fields that will be copied to codelab.json from the codelab source document without transforming them. This lets you create new simple metadata fields without modifying the source code.

This resolves #283 