### PR TITLE
Add 'prettyprint' class to code blocks if prettyprint couldnt run.

### DIFF
--- a/codelab-elements/google-codelab-step/google_codelab_step.js
+++ b/codelab-elements/google-codelab-step/google_codelab_step.js
@@ -186,6 +186,8 @@ class CodelabStep extends HTMLElement {
         const sanitizer =
             new HtmlSanitizer.Builder().withCustomTokenPolicy(identity).build();
         safe.setInnerHtml(el, sanitizer.sanitize(code));
+      } else {
+        el.classList.add('prettyprint');
       }
       this.eventHandler_.listen(
         el, 'copy', () => this.handleSnippetCopy_(el));


### PR DESCRIPTION
So that devsite-code pretty-prints it after.