### PR TITLE
Remove non-hermetic test cases from fetch_test.

### DIFF
--- a/claat/fetch/fetch_test.go
+++ b/claat/fetch/fetch_test.go
@@ -32,6 +32,9 @@ func (tt *testTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 	return tt.roundTripper(r)
 }
 
+// TODO: add tests of core functionality.
+// Must be able to fake out disk access, which probably involves a refactor focused on dependency injection?
+
 func TestGdocID(t *testing.T) {
 	tests := []struct{ in, out string }{
 		{"https://docs.google.com/document/d/foo", "foo"},


### PR DESCRIPTION
These tests were dependent on there being a token already written to
disk by a previous run of the binary. The functionality will be tested
in the future, along with a bit of refactoring to make the presence (or
lack thereof) of the token not matter.