### PR TITLE
Sample View link not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ See instructions in the [site directory's readme](site/README.md).
 
 ## How do I generate a custom view?
 
-Copy the [sample view](site/app/views/default), customize it to your liking,
+Copy the [sample view](site/app/views/vslive), customize it to your liking,
 tag and rebuild the codelabs you want included, and then generate your view.
 
 ## How do I publish my codelabs?

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ See instructions in the [site directory's readme](site/README.md).
 
 ## How do I generate a custom view?
 
-Copy the [sample view](/sample), customize it to your liking,
+Copy the [sample view](site/app/views/default), customize it to your liking,
 tag and rebuild the codelabs you want included, and then generate your view.
 
 ## How do I publish my codelabs?

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ See instructions in the [site directory's readme](site/README.md).
 
 ## How do I generate a custom view?
 
-Copy the [sample view](site/app/views/sample), customize it to your liking,
+Copy the [sample view](/sample), customize it to your liking,
 tag and rebuild the codelabs you want included, and then generate your view.
 
 ## How do I publish my codelabs?


### PR DESCRIPTION
Under create your own custom view it was linked to a non-existing folder inside the git repo. I linked it to a existing sample folder which is the vslive folder. 

The vslive is an extra sample view and users can customize it to their liking and build the view.