### PR TITLE
fix(event-drowdown): only display events dropdown if events exists

### DIFF
--- a/site/app/views/default/index.html
+++ b/site/app/views/default/index.html
@@ -151,7 +151,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           </paper-tabs>
         </div>
 
-        {% if view.id == 'default' %}
+        {% if view.id == 'default' && views|length > 1 %}
         <paper-dropdown-menu
           label="Choose an event"
           class="dropdown-filter"


### PR DESCRIPTION
Using tools for internal usecases, we don't need to use Events features so we only use the default view
If not event views was defined, the event dropdown is displayed
This fix don't display the drop-drop if no views exists