### PR TITLE
Request to add Geogebra and repl.co to iframe whitelist

### DIFF
--- a/claat/types/node.go
+++ b/claat/types/node.go
@@ -535,6 +535,8 @@ var IframeWhitelist = []string{
 	"repl.it",
 	"codepen.io",
 	"glitch.com",
+	"geogebra.org",
+	"repl.co"
 }
 
 // NewIframeNode creates a new embedded iframe.


### PR DESCRIPTION
In the mailing forum, I had requested for adding geogebra.org to whitelist.
https://groups.google.com/d/msgid/codelab-authors/CAB_EAhBwGNu92ufBeFFAt8FQTQMZZdvE%2B3FUfRjrW94XFxpGeA%40mail.gmail.com.