### PR TITLE
Markdown: Link's inline content

### DIFF
--- a/claat/parser/md/html.go
+++ b/claat/parser/md/html.go
@@ -46,19 +46,21 @@ func isMeta(hn *html.Node) bool {
 }
 
 func isBold(hn *html.Node) bool {
-	if hn.Type == html.TextNode {
-		hn = hn.Parent
+	for n := hn; n != nil; n = n.Parent {
+		if n.DataAtom == atom.Strong || n.DataAtom == atom.B {
+			return true
+		}
 	}
-	return hn.DataAtom == atom.Strong ||
-		hn.DataAtom == atom.B
+	return false
 }
 
 func isItalic(hn *html.Node) bool {
-	if hn.Type == html.TextNode {
-		hn = hn.Parent
+	for n := hn; n != nil; n = n.Parent {
+		if n.DataAtom == atom.Em || n.DataAtom == atom.I {
+			return true
+		}
 	}
-	return hn.DataAtom == atom.Em ||
-		hn.DataAtom == atom.I
+	return false
 }
 
 func isConsole(hn *html.Node) bool {
@@ -69,10 +71,12 @@ func isConsole(hn *html.Node) bool {
 }
 
 func isCode(hn *html.Node) bool {
-	if hn.Type == html.TextNode {
-		hn = hn.Parent
+	for n := hn; n != nil; n = n.Parent {
+		if n.DataAtom == atom.Code && n.Parent.DataAtom == atom.Pre {
+			return true
+		}
 	}
-	return hn.DataAtom == atom.Code && hn.Parent.DataAtom == atom.Pre
+	return false
 }
 
 func isButton(hn *html.Node) bool {

--- a/claat/parser/md/parse.go
+++ b/claat/parser/md/parse.go
@@ -756,29 +756,23 @@ func button(ds *docState) types.Node {
 // It returns nil if hn contents is empty.
 // The resuling link's content is always a single text node.
 func link(ds *docState) types.Node {
-	href := nodeAttr(ds.cur, "href")
-
-	text := stringifyNode(ds.cur, false)
-	if strings.TrimSpace(text) == "" {
+	ds.push(nil)
+	nodes := parseSubtree(ds)
+	ds.pop()
+	if len(nodes) == 0 {
 		return nil
 	}
 
-	t := types.NewTextNode(text)
-	if isBold(ds.cur.Parent) {
-		t.Bold = true
-	}
-	if isItalic(ds.cur.Parent) {
-		t.Italic = true
-	}
-	if isCode(ds.cur.Parent) {
-		t.Code = true
-	}
+	href := nodeAttr(ds.cur, "href")
+
 	if href == "" || href[0] == '#' {
-		t.MutateBlock(findBlockParent(ds.cur))
-		return t
+		l := types.NewListNode(nodes...)
+		l.MutateBlock(findBlockParent(ds.cur))
+		return l
 	}
 
-	n := types.NewURLNode(href, t)
+	n := types.NewURLNode(href, nodes...)
+
 	n.Name = nodeAttr(ds.cur, "name")
 	if v := nodeAttr(ds.cur, "target"); v != "" {
 		n.Target = v


### PR DESCRIPTION
Allow links to have inline elements such as images.

### Example
With the following markdown:
```markdown
[![Alt text](image.jpg)](https://example.com)
```

The link and the image were discarded.

With this PR the HTML output is:
```html
<p>
  <a href="https://example.com">
    <img src="hash.jpg">
  </a>
</p>
```