### PR TITLE
fix single newline in markdown input

### DIFF
--- a/claat/parser/md/html.go
+++ b/claat/parser/md/html.go
@@ -221,6 +221,7 @@ func nodeAttr(n *html.Node, name string) string {
 func stringifyNode(root *html.Node, trim bool) string {
 	if root.Type == html.TextNode {
 		s := textCleaner.Replace(root.Data)
+		s = strings.Replace(s, "\n", " ", -1)
 		if !trim {
 			return s
 		}


### PR DESCRIPTION
fixes #58 

newlines in markdown no longer trigger html breaks but double spaces and double newlines still do (as required by common markdown)