### PR TITLE
Add fragment import support for Markdown

### DIFF
--- a/claat/fetch/fetch.go
+++ b/claat/fetch/fetch.go
@@ -238,12 +238,29 @@ func (f *Fetcher) slurpBytes(codelabSrc, dir, imgURL string) (string, error) {
 }
 
 func (f *Fetcher) slurpFragment(url string) ([]types.Node, error) {
-	res, err := f.fetchRemote(url, true)
+	res, err := f.fetchResource(url)
 	if err != nil {
 		return nil, err
 	}
 	defer res.body.Close()
+
 	return parser.ParseFragment(string(res.typ), res.body)
+}
+
+func (f *Fetcher) fetchResource(name string) (*resource, error) {
+	fi, err := os.Stat(name)
+	if os.IsNotExist(err) {
+		return f.fetchRemote(name, true)
+	}
+	r, err := os.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	return &resource{
+		body: r,
+		typ:  SrcMarkdown,
+		mod:  fi.ModTime(),
+	}, nil
 }
 
 // fetch retrieves codelab doc either from local disk


### PR DESCRIPTION
Adds support for fragment import for Markdown. It's mostly just copied from the gdoc implementation. This seems to work for my purposes right now, but I'll see if I can improve on it a bit. Would appreciate feedback.

Right now, import paths are relative to where the `claat export` command is run. I think it would probably make more sense to have it relative to the file importing it.

Fixes  #324