### PR TITLE
Enable markdown buttons

### DIFF
--- a/claat/parser/md/html.go
+++ b/claat/parser/md/html.go
@@ -76,7 +76,7 @@ func isCode(hn *html.Node) bool {
 }
 
 func isButton(hn *html.Node) bool {
-        return hn.DataAtom == atom.Button
+	return hn.DataAtom == atom.Button
 }
 
 func isInfobox(hn *html.Node) bool {

--- a/claat/parser/md/html.go
+++ b/claat/parser/md/html.go
@@ -76,8 +76,7 @@ func isCode(hn *html.Node) bool {
 }
 
 func isButton(hn *html.Node) bool {
-	// TODO: implements
-	return false
+        return hn.DataAtom == atom.Button
 }
 
 func isInfobox(hn *html.Node) bool {


### PR DESCRIPTION
This PR enables the `isButton` check in the md html parser. It checks if the node in question is a Button atom.