### PR TITLE
Fix for the build issues where HTTPS is now mandatory on maven and Closure is missing.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -71,11 +71,6 @@ maven_jar(
 )
 
 maven_jar(
-    name = "com_google_javascript_closure_compiler",
-    artifact = "com.google.javascript:closure-compiler-unshaded:v20180805",
-)
-
-maven_jar(
     name = "commons_logging",
     artifact = "commons-logging:commons-logging:1.2",
 )
@@ -88,6 +83,17 @@ maven_jar(
 maven_jar(
     name = "org_hamcrest_core",
     artifact = "org.hamcrest:hamcrest-core:1.3",
+)
+
+# maven_jar(
+#     name = "com_google_javascript_closure_compiler",
+#     artifact = "com.google.javascript:closure-compiler-unshaded:v20180805",
+#     sha1 = "e64e10e00ce86b0780dd2bd5e46d0f1c7e4e1062",
+# )
+
+http_archive(
+    name = "com_google_javascript_closure_compiler",
+    url = "https://repo1.maven.org/maven2/com/google/javascript/closure-compiler-unshaded/v20180805/closure-compiler-unshaded-v20180805.jar",
 )
 
 # Required by io_bazel_rules_webtesting.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,95 @@
 workspace(name = "googlecodelabs_custom_elements")
 
+maven_server(
+    name = "default",
+    url = "https://repo1.maven.org/maven2/"
+)
+
+maven_jar(
+    name = "org_apache_httpcomponents_httpclient",
+    artifact = "org.apache.httpcomponents:httpclient:4.5.5",
+)
+
+maven_jar(
+    name = "org_apache_httpcomponents_httpmime",
+    artifact = "org.apache.httpcomponents:httpmime:4.5.5",
+)
+
+maven_jar(
+    name = "org_apache_httpcomponents_httpcore",
+    artifact = "org.apache.httpcomponents:httpcore:4.4.9",
+)
+
+maven_jar(
+    name = "org_apache_commons_exec",
+    artifact = "org.apache.commons:commons-exec:1.3",
+)
+
+maven_jar(
+    name = "org_seleniumhq_selenium_api",
+    artifact = "org.seleniumhq:selenium-api:3.9.1",
+)
+
+maven_jar(
+    name = "org_seleniumhq_selenium_remote_driver",
+    artifact = "org.seleniumhq.selenium:selenium-remote-driver:3.8.1",
+)
+
+maven_jar(
+    name = "net_java_dev_jna_platform",
+    artifact = "net.java.dev:jna-client:4.5.1",
+)
+
+maven_jar(
+    name = "net_java_dev_jna",
+    artifact = "net.java.dev:jna:4.5.1",
+)
+
+maven_jar(
+    name = "net_bytebuddy",
+    artifact = "net.bytebuddy:byte-buddy:1.7.9",
+)
+
+maven_jar(
+    name = "com_squareup_okio",
+    artifact = "com.squareup:okio:1.14.0",
+)
+
+maven_jar(
+    name = "com_squareup_okhttp3_okhttp",
+    artifact = "com.squareup.okhttp3:okhttp:3.9.1",
+)
+
+maven_jar(
+    name = "cglib_nodep",
+    artifact = "cglib:cglib-nodep:3.2.6",
+)
+
+maven_jar(
+    name = "junit",
+    artifact = "junit:junit:4.12",
+)
+
+maven_jar(
+    name = "com_google_javascript_closure_compiler",
+    artifact = "com.google.javascript:closure-compiler-unshaded:v20180805",
+)
+
+maven_jar(
+    name = "commons_logging",
+    artifact = "commons-logging:commons-logging:1.2",
+)
+
+maven_jar(
+    name = "commons_codec",
+    artifact = "commons-codec:commons-codec:1.11",
+)
+
+maven_jar(
+    name = "org_hamcrest_core",
+    artifact = "org.hamcrest:hamcrest-core:1.3",
+)
+
 # Required by io_bazel_rules_webtesting.
 skylib_ver = "f9b0ff1dd3d119d19b9cacbbc425a9e61759f1f5"
 http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -91,10 +91,11 @@ maven_jar(
 #     sha1 = "e64e10e00ce86b0780dd2bd5e46d0f1c7e4e1062",
 # )
 
-http_archive(
-    name = "com_google_javascript_closure_compiler",
-    url = "https://repo1.maven.org/maven2/com/google/javascript/closure-compiler-unshaded/v20180805/closure-compiler-unshaded-v20180805.jar",
-)
+# http_archive(
+#     name = "com_google_javascript_closure_compiler",
+#     strip_prefix = "closure-compiler-unshaded-v20180805",
+#     url = "https://repo1.maven.org/maven2/com/google/javascript/closure-compiler-unshaded/v20180805/closure-compiler-unshaded-v20180805.jar",
+# )
 
 # Required by io_bazel_rules_webtesting.
 skylib_ver = "f9b0ff1dd3d119d19b9cacbbc425a9e61759f1f5"

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -85,17 +85,11 @@ maven_jar(
     artifact = "org.hamcrest:hamcrest-core:1.3",
 )
 
-# maven_jar(
-#     name = "com_google_javascript_closure_compiler",
-#     artifact = "com.google.javascript:closure-compiler-unshaded:v20180805",
-#     sha1 = "e64e10e00ce86b0780dd2bd5e46d0f1c7e4e1062",
-# )
-
-# http_archive(
-#     name = "com_google_javascript_closure_compiler",
-#     strip_prefix = "closure-compiler-unshaded-v20180805",
-#     url = "https://repo1.maven.org/maven2/com/google/javascript/closure-compiler-unshaded/v20180805/closure-compiler-unshaded-v20180805.jar",
-# )
+new_http_archive(
+    name = "com_google_javascript_closure_compiler",
+    build_file = "third_party/BUILD.closure",
+    url = "https://repo1.maven.org/maven2/com/google/javascript/closure-compiler-unshaded/v20180805/closure-compiler-unshaded-v20180805.jar",
+)
 
 # Required by io_bazel_rules_webtesting.
 skylib_ver = "f9b0ff1dd3d119d19b9cacbbc425a9e61759f1f5"

--- a/third_party/BUILD.closure
+++ b/third_party/BUILD.closure
@@ -1,0 +1,19 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["reciprocal"])
+
+java_import(
+    name = "com_google_javascript_closure_compiler",
+    jars = ["closure-compiler-unshaded-v20180805.jar"],
+    deps = ["@com_google_code_gson", "@com_google_guava", "@com_google_code_findbugs_jsr305", "@com_google_protobuf//:protobuf_java"],
+)
+
+java_binary(
+    name = "main",
+    main_class = "com.google.javascript.jscomp.CommandLineRunner",
+    output_licenses = ["unencumbered"],
+    runtime_deps = [
+        ":com_google_javascript_closure_compiler",
+        "@args4j",
+    ],
+)


### PR DESCRIPTION
2 Issues:
 - Maven has started rejecting non-SSL requests and so a bunch of Bazel Java dependencies could not download anymore because we use a really old version of Bazel that reference these dependencies via non-SSL URL.
 - The Bazel mirror of Maven is not mirroring the version of the closure compiler that we need anymore. I filed this here: https://github.com/bazelbuild/rules_closure/issues/472

One option is to update all our BUILD files to the latest version of Bazel. This is a temporary fix in order to download all dependencies that works with our current version of Bazel.