### PR TITLE
Enable YouTube support via markdown

### DIFF
--- a/claat/parser/md/html.go
+++ b/claat/parser/md/html.go
@@ -111,6 +111,10 @@ func isList(hn *html.Node) bool {
 	return hn.DataAtom == atom.Ul || hn.DataAtom == atom.Ol
 }
 
+func isYoutube(hn *html.Node) bool {
+	return hn.DataAtom == atom.Video
+}
+
 // countTwo starts counting the number of a Atom children in hn.
 // It returns as soon as the count exceeds 1, so the returned value is inexact.
 //

--- a/claat/parser/md/parse.go
+++ b/claat/parser/md/parse.go
@@ -306,6 +306,8 @@ func parseNode(ds *docState) (types.Node, bool) {
 		return survey(ds), true
 	case isTable(ds.cur):
 		return table(ds), true
+	case isYoutube(ds.cur):
+		return youtube(ds), true
 	}
 	return nil, false
 }
@@ -696,17 +698,14 @@ func image(ds *docState) types.Node {
 }
 
 func youtube(ds *docState) types.Node {
-	u, err := url.Parse(nodeAttr(ds.cur, "alt"))
-	if err != nil {
-		return nil
+	for _, attr := range ds.cur.Attr {
+		if attr.Key == "id" {
+			n := types.NewYouTubeNode(attr.Val)
+			n.MutateBlock(true)
+			return n
+		}
 	}
-	v := u.Query().Get("v")
-	if v == "" {
-		return nil
-	}
-	n := types.NewYouTubeNode(v)
-	n.MutateBlock(true)
-	return n
+	return nil
 }
 
 func iframe(ds *docState) types.Node {


### PR DESCRIPTION
This PR enables YouTube support via markdown.

Expected markdown for including YouTube video in codelab:

```
<video id="ID_OF_YOUTUBE_VIDEO"></video>
```

