### PR TITLE
Added carto.com to the iframewhitelist

### DIFF
--- a/claat/types/node.go
+++ b/claat/types/node.go
@@ -535,6 +535,7 @@ var IframeWhitelist = []string{
 	"repl.it",
 	"codepen.io",
 	"glitch.com",
+	"carto.com",
 }
 
 // NewIframeNode creates a new embedded iframe.


### PR DESCRIPTION
CARTO.com provides a map service that can be very useful when making cartographic tutorials.