### PR TITLE
Parse <<path>> for markdown imports

### DIFF
--- a/claat/cmd/testdata/fragments/import-test-fragment1.md
+++ b/claat/cmd/testdata/fragments/import-test-fragment1.md
@@ -1,0 +1,2 @@
+### Fragment 1
+content 1

--- a/claat/cmd/testdata/fragments/import-test-fragment2.md
+++ b/claat/cmd/testdata/fragments/import-test-fragment2.md
@@ -1,0 +1,2 @@
+### Fragment 2
+content 2

--- a/claat/cmd/testdata/import-test.md
+++ b/claat/cmd/testdata/import-test.md
@@ -1,0 +1,19 @@
+author: Sida Chen
+summary: Import Test
+id: import test
+
+<<fragments/import-test-fragment1.md>> <!-- not going to show-->
+
+# Sample Codelab
+
+<<fragments/import-test-fragment1.md>> <!--not going to show-->
+
+## Step 1
+
+Duration 00:01:00
+
+<<fragments/import-test-fragment1.md>>
+
+<<fragments/import-test-fragment2.md>>
+
+You would still need manual testing

--- a/claat/fetch/fetch.go
+++ b/claat/fetch/fetch.go
@@ -271,7 +271,7 @@ func (f *Fetcher) slurpBytes(codelabSrc, dir, imgURL string) (string, error) {
 }
 
 func (f *Fetcher) slurpFragment(url string) ([]types.Node, error) {
-	res, err := f.fetchRemote(url, true)
+	res, err := f.fetch(url)
 	if err != nil {
 		return nil, err
 	}

--- a/claat/parser/md/html.go
+++ b/claat/parser/md/html.go
@@ -121,6 +121,10 @@ func isYoutube(hn *html.Node) bool {
 	return hn.DataAtom == atom.Video
 }
 
+func isFragmentImport(hn *html.Node) bool {
+	return hn.DataAtom == 0 && strings.HasPrefix(hn.Data, convertedImportsDataPrefix)
+}
+
 // countTwo starts counting the number of a Atom children in hn.
 // It returns as soon as the count exceeds 1, so the returned value is inexact.
 //

--- a/claat/parser/md/parse.go
+++ b/claat/parser/md/parse.go
@@ -66,7 +66,7 @@ const (
 )
 
 var (
-	importsTagRegexp           = regexp.MustCompile("^<<([^<>()]+)>>\\s*$")
+	importsTagRegexp           = regexp.MustCompile("^<<([^<>()]+.md)>>\\s*$")
 	convertedImportsDataPrefix = "__unsupported_import_zmcgv2epyv="
 	convertedImportsPrefix     = []byte("<!--" + convertedImportsDataPrefix)
 	convertedImportsSuffix     = []byte("-->")

--- a/claat/parser/md/parse.go
+++ b/claat/parser/md/parse.go
@@ -65,6 +65,13 @@ const (
 	headerFAQ   = "frequently asked questions"
 )
 
+var (
+	importsTagRegexp           = regexp.MustCompile("^<<([^<>()]+)>>\\s*$")
+	convertedImportsDataPrefix = "__unsupported_import_zmcgv2epyv="
+	convertedImportsPrefix     = []byte("<!--" + convertedImportsDataPrefix)
+	convertedImportsSuffix     = []byte("-->")
+)
+
 var metadataRegexp = regexp.MustCompile(`(.+?):(.+)`)
 var languageRegexp = regexp.MustCompile(`language-(.+)`)
 
@@ -104,7 +111,7 @@ func (p *Parser) Parse(r io.Reader, opts parser.Options) (*types.Codelab, error)
 	if err != nil {
 		return nil, err
 	}
-	b = claatMarkdown(b)
+	b = renderToHTML(b)
 	h := bytes.NewBuffer(b)
 	doc, err := html.Parse(h)
 	if err != nil {
@@ -120,7 +127,7 @@ func (p *Parser) ParseFragment(r io.Reader) ([]types.Node, error) {
 	if err != nil {
 		return nil, err
 	}
-	b = claatMarkdown(b)
+	b = renderToHTML(b)
 	h := bytes.NewBuffer(b)
 	doc, err := html.Parse(h)
 	if err != nil {
@@ -137,7 +144,6 @@ func parsePartialMarkup(root *html.Node) ([]types.Node, error) {
 	}
 
 	ds := newDocState()
-	ds.partial = true
 	ds.step = ds.clab.NewStep("fragment")
 	for ds.cur = body.FirstChild; ds.cur != nil; ds.cur = ds.cur.NextSibling {
 		switch {
@@ -151,6 +157,10 @@ func parsePartialMarkup(root *html.Node) ([]types.Node, error) {
 	}
 
 	finalizeStep(ds.step)
+	if hasImport(ds) {
+		return nil, ErrForbiddenFragmentImports
+	}
+
 	return ds.step.Content.Nodes, nil
 }
 
@@ -163,7 +173,6 @@ type docState struct {
 	env      []string       // current enviornment
 	cur      *html.Node     // current HTML node
 	stack    []*stackItem   // cur and flags stack
-	partial  bool           // true if the document currently being parsed should be treated as a fragment
 }
 
 type stackItem struct {
@@ -207,9 +216,11 @@ func (ds *docState) appendNodes(nn ...types.Node) {
 	ds.lastNode = nn[len(nn)-1]
 }
 
-// claatMarkdown calls the Blackfriday Markdown parser with some special addons selected. It takes a byte slice as a parameter,
-// and returns its result as a byte slice.
-func claatMarkdown(b []byte) []byte {
+// renderToHTML preprocesses markdown bytes and then calls the Blackfriday Markdown parser with some special addons selected.
+// It takes a raw markdown bytes and output parsed xhtml in bytes.
+func renderToHTML(b []byte) []byte {
+	b = convertImports(b)
+
 	htmlFlags := blackfriday.UseXHTML |
 		blackfriday.Smartypants |
 		blackfriday.SmartypantsFractions |
@@ -351,6 +362,8 @@ func parseNode(ds *docState) (types.Node, bool) {
 		return table(ds), true
 	case isYoutube(ds.cur):
 		return youtube(ds), true
+	case isFragmentImport(ds.cur):
+		return fragmentImport(ds), true
 	}
 	return nil, false
 }
@@ -745,6 +758,14 @@ func youtube(ds *docState) types.Node {
 	return nil
 }
 
+func fragmentImport(ds *docState) types.Node {
+	if url := strings.TrimPrefix(ds.cur.Data, convertedImportsDataPrefix); url != "" {
+		return types.NewImportNode(url)
+	}
+
+	return nil
+}
+
 func iframe(ds *docState) types.Node {
 	u, err := url.Parse(nodeAttr(ds.cur, "alt"))
 	if err != nil {
@@ -900,4 +921,35 @@ func roundDuration(d time.Duration) time.Duration {
 		rd += time.Minute
 	}
 	return rd
+}
+
+func convertImports(content []byte) []byte {
+	slices := bytes.Split(content, []byte("\n"))
+	escaped := [][]byte{}
+	for _, slice := range slices {
+		if matches := importsTagRegexp.FindSubmatch(slice); len(matches) > 0 {
+			if len(matches) > 1 {
+				url := string(matches[1])
+				slice = bytes.Join([][]byte{
+					convertedImportsPrefix,
+					[]byte(html.EscapeString(url)),
+					convertedImportsSuffix,
+				}, []byte(""))
+			}
+		}
+
+		escaped = append(escaped, slice)
+	}
+
+	return bytes.Join(escaped, []byte("\n"))
+}
+
+func hasImport(ds *docState) bool {
+	for _, step := range ds.clab.Steps {
+		if len(types.ImportNodes(step.Content.Nodes)) > 0 {
+			return true
+		}
+	}
+
+	return false
 }

--- a/claat/parser/md/parse_test.go
+++ b/claat/parser/md/parse_test.go
@@ -347,23 +347,23 @@ with space
 			input: stdHeader + `
 ## Step 1 <<This is not allowed>>
 <<not like this>><<not like this>>
-<<this is ok>>
+<<this is ok.md>>
 <<but not this>>this line
 
 <<strange case is here and should not be allowed>>## Step 2
 <<you cannot do this ## Step 3>> Otherwise it's really broken.
 		`,
-			want: []string{"this is ok"},
+			want: []string{"this is ok.md"},
 		},
 		{
 			name: "import inside code block should not be considered",
 			input: stdHeader + `
 ## Step 1
 		` + "```" + `
-<<I guess we should consider it here>>
+<<I guess we should consider it here.md>>
 		` + "```" + `
 		`,
-			want: []string{"I guess we should consider it here"},
+			want: []string{"I guess we should consider it here.md"},
 		},
 		{
 			name: "HTML injection is not allowed",
@@ -377,6 +377,14 @@ I'm going to inject some HTML
 <<--document.write("random stuff")>>
 </script>
 `,
+		},
+		{
+			name: "nonmarkdown file is currently not supported",
+			input: stdHeader + `
+## Step 1
+<<nonmd file.gdoc>>
+<<somemd.md>>`,
+			want: []string{"somemd.md"},
 		},
 	}
 


### PR DESCRIPTION
Example is provided in claat/cmd/testdata/import-test.md.

User writes

```
<<path>>
```

in the markdown file to import another markdown fragment file.

Note that if user want to use `<<path>>` literal in the code block, they need to do

\`\`\`
(at least one space here) \<\<path\>\>
\`\`\`

otherwise, it'll be interpreted as import command.

Path can be local file path, relative or absolute, or remote path in Google drive, or gdoc (I think that will work as well).

-----

Side Note on the implementation:
The syntax:

```
<<path>>
```

has a lot of problems with the HTML syntax and character escaping. 

So the solution is to preprocess it and convert this into

```
<!--__unsupported_import_zmcgv2epyv=path-->
```

HTML comment for extremely easy parsing without big change in the HTML parsing process. And if people put this in wrong places e.g. before any step, it'll be hidden because that's a html comment.

__unsupported_import_zmcgv2epyv contains a random string just to yell at people "you should not use this yourself!" and it's subject to be changed in the future if there's a need (I guess not).
