### PR TITLE
Fix link styling 

### DIFF
--- a/claat/parser/md/parse.go
+++ b/claat/parser/md/parse.go
@@ -815,27 +815,22 @@ func button(ds *docState) types.Node {
 func link(ds *docState) types.Node {
 	href := nodeAttr(ds.cur, "href")
 
-	text := stringifyNode(ds.cur, false)
-	if strings.TrimSpace(text) == "" {
-		return nil
+	ds.push(nil)
+	parsedChildNodes := parseSubtree(ds)
+	ds.pop()
+
+	// Check outside styles
+	outsideBold := isBold(ds.cur.Parent)
+	outsideItalic := isItalic(ds.cur.Parent)
+	// Apply outside styles to inside parsed (text) nodes
+	for _, node := range parsedChildNodes {
+		if textNode, ok := node.(*types.TextNode); ok {
+			textNode.Bold = textNode.Bold || outsideBold
+			textNode.Italic = textNode.Italic || outsideItalic
+		}
 	}
 
-	t := types.NewTextNode(text)
-	if isBold(ds.cur.Parent) {
-		t.Bold = true
-	}
-	if isItalic(ds.cur.Parent) {
-		t.Italic = true
-	}
-	if isCode(ds.cur.Parent) {
-		t.Code = true
-	}
-	if href == "" || href[0] == '#' {
-		t.MutateBlock(findBlockParent(ds.cur))
-		return t
-	}
-
-	n := types.NewURLNode(href, t)
+	n := types.NewURLNode(href, parsedChildNodes...)
 	n.Name = nodeAttr(ds.cur, "name")
 	if v := nodeAttr(ds.cur, "target"); v != "" {
 		n.Target = v


### PR DESCRIPTION
(ignore branch name) 

Previously, link text could only be styled on the outside such as  `_[text](link)_`, and inside styling would be ignored. Now, both are respected and compounding the two styling methods works also. 

E.g. `[*text*](link)` now correctly gives [*text*](#)
Styles can compound, so `_[**text**](link)_` now correctly gives _[**text**](#)_
