### PR TITLE
 Fix md parser excluding table headers

### DIFF
--- a/claat/parser/md/parse.go
+++ b/claat/parser/md/parse.go
@@ -573,8 +573,13 @@ func table(ds *docState) types.Node {
 
 func tableRow(ds *docState) []*types.GridCell {
 	var row []*types.GridCell
-	for td := findAtom(ds.cur, atom.Td); td != nil; td = td.NextSibling {
-		if td.DataAtom != atom.Td {
+	firstChild := findAtom(ds.cur, atom.Td)
+	// If there is no Td child found, could be table header so look for Th
+	if firstChild == nil {
+		firstChild = findAtom(ds.cur, atom.Th)
+	}
+	for td := firstChild; td != nil; td = td.NextSibling {
+		if td.DataAtom != atom.Td && td.DataAtom != atom.Th {
 			continue
 		}
 		ds.push(td)

--- a/claat/parser/md/parse.go
+++ b/claat/parser/md/parse.go
@@ -561,7 +561,6 @@ func table(ds *docState) types.Node {
 	var rows [][]*types.GridCell
 	for _, tr := range findChildAtoms(ds.cur, atom.Tr) {
 		ds.push(tr)
-		fmt.Println(tr)
 		r := tableRow(ds)
 		ds.pop()
 		fmt.Println(r)
@@ -580,7 +579,7 @@ func tableRow(ds *docState) []*types.GridCell {
 	if firstChild == nil {
 		firstChild = findAtom(ds.cur, atom.Th)
 	}
-	
+
 	for td := firstChild; td != nil; td = td.NextSibling {
 		if td.DataAtom != atom.Td && td.DataAtom != atom.Th {
 			continue

--- a/claat/parser/md/parse.go
+++ b/claat/parser/md/parse.go
@@ -563,7 +563,6 @@ func table(ds *docState) types.Node {
 		ds.push(tr)
 		r := tableRow(ds)
 		ds.pop()
-		fmt.Println(r)
 		rows = append(rows, r)
 	}
 	if len(rows) == 0 {


### PR DESCRIPTION
Previously, tables would erroneously have their headers removed when parsed as the parser was not looking for `<th>` html elements and only `<td>` nodes