### PR TITLE
Fix bolditalics bug in links (md parser)

### DIFF
--- a/claat/parser/md/parse.go
+++ b/claat/parser/md/parse.go
@@ -828,6 +828,10 @@ func link(ds *docState) types.Node {
 	// Check outside styles
 	outsideBold := isBold(ds.cur.Parent)
 	outsideItalic := isItalic(ds.cur.Parent)
+	if isBoldAndItalic(ds.cur.Parent) {
+		outsideBold = true
+		outsideItalic = true
+	}
 	// Apply outside styles to inside parsed (text) nodes
 	for _, node := range parsedChildNodes {
 		if textNode, ok := node.(*types.TextNode); ok {


### PR DESCRIPTION
Similarly to styling text, when styling the text inside links we must check for the additional case for a node being styled both bold and italic

