### PR TITLE
Fix youtube nodes in md renderer

### DIFF
--- a/claat/render/md.go
+++ b/claat/render/md.go
@@ -114,8 +114,8 @@ func (mw *mdWriter) write(nodes ...types.Node) error {
 		//	mw.survey(n)
 		case *types.HeaderNode:
 			mw.header(n)
-			//case *types.YouTubeNode:
-			//	mw.youtube(n)
+		case *types.YouTubeNode:
+			mw.youtube(n)
 		}
 		if mw.err != nil {
 			return mw.err
@@ -261,4 +261,11 @@ func (mw *mdWriter) header(n *types.HeaderNode) {
 	if !mw.lineStart {
 		mw.writeBytes(newLine)
 	}
+}
+
+func (mw *mdWriter) youtube(n *types.YouTubeNode) {
+	mw.newBlock()
+	mw.writeString(`<video id="`)
+	mw.writeString(n.VideoID)
+	mw.writeString(`"></video>`)
 }

--- a/claat/render/md.go
+++ b/claat/render/md.go
@@ -265,7 +265,5 @@ func (mw *mdWriter) header(n *types.HeaderNode) {
 
 func (mw *mdWriter) youtube(n *types.YouTubeNode) {
 	mw.newBlock()
-	mw.writeString(`<video id="`)
-	mw.writeString(n.VideoID)
-	mw.writeString(`"></video>`)
+	mw.writeString(fmt.Sprintf(`<video id="%s"></video>`, n.VideoID))
 }


### PR DESCRIPTION
Previously, when compiling a gdoc codelab to markdown, embedded youtube videos would be ignored

Now they are properly rendered using the chosen youtube syntax defined in https://github.com/googlecodelabs/tools/pull/400