### PR TITLE
Add github to allowlist of iframe domains

### DIFF
--- a/claat/types/node.go
+++ b/claat/types/node.go
@@ -536,6 +536,7 @@ var IframeWhitelist = []string{
 	"codepen.io",
 	"glitch.com",
 	"carto.com",
+	"github.com",
 }
 
 // NewIframeNode creates a new embedded iframe.


### PR DESCRIPTION
Allowing for codelabs to render GitHub pages might be useful to refer to other code or documentation pages (READMEs, for instance).