### PR TITLE
Add support for blockquote syntax for asides.

### DIFF
--- a/claat/parser/md/html.go
+++ b/claat/parser/md/html.go
@@ -96,6 +96,19 @@ func isAside(hn *html.Node) bool {
 	return hn.DataAtom == atom.Aside
 }
 
+func isNewAside(hn *html.Node) bool {
+	if hn.FirstChild == nil ||
+	   hn.FirstChild.NextSibling == nil ||
+	   hn.FirstChild.NextSibling.FirstChild == nil {
+		return false
+	}
+
+	bq := hn.DataAtom == atom.Blockquote
+	apn := strings.HasPrefix(strings.ToLower(hn.FirstChild.NextSibling.FirstChild.Data), "aside positive") ||
+	       strings.HasPrefix(strings.ToLower(hn.FirstChild.NextSibling.FirstChild.Data), "aside negative")
+	return bq && apn
+}
+
 func isInfobox(hn *html.Node) bool {
 	if hn.DataAtom != atom.Dt {
 		return false

--- a/claat/types/node.go
+++ b/claat/types/node.go
@@ -241,11 +241,13 @@ func (gn *GridNode) Empty() bool {
 // Provide a positive start to make this a numbered list.
 // NodeItemsCheck and NodeItemsFAQ are always unnumbered.
 func NewItemsListNode(typ string, start int) *ItemsListNode {
-	return &ItemsListNode{
+	iln := ItemsListNode{
 		node:     node{typ: NodeItemsList},
 		ListType: typ,
 		Start:    start,
 	}
+	iln.MutateBlock(true)
+	return &iln
 }
 
 // ItemsListNode containts sets of ListNode.


### PR DESCRIPTION
This changes the gdoc -> md flow to output a blockquote for asides instead of a definition list. It also adds support for that blockquote syntax in the md -> html flow.