### PR TITLE
Add support for language hint in code blocks and console blocks

### DIFF
--- a/claat/parser/gdoc/parse.go
+++ b/claat/parser/gdoc/parse.go
@@ -622,7 +622,8 @@ func code(ds *docState, term bool) types.Node {
 	} else if ds.cur.Parent.FirstChild == ds.cur && ds.cur.Parent.DataAtom != atom.Span {
 		v = "\n" + v
 	}
-	n := types.NewCodeNode(v, term)
+	var lang string;
+	n := types.NewCodeNode(v, term, lang)
 	n.MutateBlock(td)
 	return n
 }

--- a/claat/parser/gdoc/parse_test.go
+++ b/claat/parser/gdoc/parse_test.go
@@ -110,8 +110,9 @@ func TestParseTopCodeBlock(t *testing.T) {
 	code := "start func() {\n}\n\nfunc2() {\n} // comment"
 	term := "adb shell am start -a VIEW \\\n-d \"http://host\" app"
 	content := types.NewListNode()
-	content.Append(types.NewCodeNode(code, false))
-	content.Append(types.NewCodeNode(term, true))
+	var lang string;
+	content.Append(types.NewCodeNode(code, false, lang))
+	content.Append(types.NewCodeNode(term, true, lang))
 
 	doc, err := html.Parse(markupReader(markup))
 	if err != nil {
@@ -491,13 +492,14 @@ func TestParseDoc(t *testing.T) {
 		"http://host/file.java", types.NewTextNode("a file")))
 	content.Append(h)
 
+	var lang string;
 	code := "start func() {\n}\n\nfunc2() {\n} // comment"
-	cn := types.NewCodeNode(code, false)
+	cn := types.NewCodeNode(code, false, lang)
 	cn.MutateBlock(1)
 	content.Append(cn)
 
 	term := "adb shell am start -a VIEW \\\n-d \"http://host\" app"
-	tn := types.NewCodeNode(term, true)
+	tn := types.NewCodeNode(term, true, lang)
 	tn.MutateBlock(2)
 	content.Append(tn)
 

--- a/claat/parser/md/README.md
+++ b/claat/parser/md/README.md
@@ -72,8 +72,15 @@ perform syntax highlighting on code blocks, but it is not always effective at
 guessing the language to highlight in. Put the name of the code language after
 the first fence to explicitly specify which highlighting plan to use.
 
-    ``` go
+    ```go
     This block will be highlighted as Go source code.
+    ```
+
+If you'd like to disable syntax highlighting, you can specify the language
+hint to "console":
+
+    ```console
+    This block will not be syntax highlighted.
     ```
 
 #### Info Boxes

--- a/claat/parser/md/html.go
+++ b/claat/parser/md/html.go
@@ -75,17 +75,24 @@ func isBoldAndItalic(hn *html.Node) bool {
 }
 
 func isConsole(hn *html.Node) bool {
-	if hn.Type == html.TextNode {
-		hn = hn.Parent
-	}
-	return hn.DataAtom == atom.Code && hn.Parent.DataAtom != atom.Pre
+    if hn.Type == html.TextNode {
+        hn = hn.Parent
+    }
+    if (hn.DataAtom == atom.Code) {
+        for _, a := range hn.Attr {
+            if (a.Key == "class" && a.Val == "language-console") {
+                return true;
+            }
+        }
+    }
+    return false;
 }
 
 func isCode(hn *html.Node) bool {
 	if hn.Type == html.TextNode {
 		hn = hn.Parent
 	}
-	return hn.DataAtom == atom.Code && hn.Parent.DataAtom == atom.Pre
+	return hn.DataAtom == atom.Code && !isConsole(hn)
 }
 
 func isButton(hn *html.Node) bool {

--- a/claat/parser/md/parse.go
+++ b/claat/parser/md/parse.go
@@ -709,7 +709,16 @@ func code(ds *docState, term bool) types.Node {
 	} else if ds.cur.Parent.FirstChild == ds.cur && ds.cur.Parent.DataAtom != atom.Span {
 		v = "\n" + v
 	}
-	n := types.NewCodeNode(v, term)
+	// get the language hint
+	var lan string;
+	if (!term) {
+		for _, a := range ds.cur.Attr {
+			if (a.Key == "class" && strings.HasPrefix(a.Val, "language-")) {
+				lan = strings.Replace(a.Val, "language-", "", 0);
+			}
+		}
+	}
+	n := types.NewCodeNode(v, term, lan)
 	n.MutateBlock(elem)
 	return n
 }

--- a/claat/render/md.go
+++ b/claat/render/md.go
@@ -218,8 +218,10 @@ func (mw *mdWriter) code(n *types.CodeNode) {
 	mw.writeString("```")
 	if n.Term {
 		mw.writeString("console")
-	} else {
+	} else if (len(n.Lang) > 0) {
 		mw.writeString(n.Lang)
+	} else {
+		mw.writeString("auto")
 	}
 	mw.writeBytes(newLine)
 	mw.writeString(n.Value)

--- a/claat/render/md.go
+++ b/claat/render/md.go
@@ -215,22 +215,12 @@ func (mw *mdWriter) url(n *types.URLNode) {
 func (mw *mdWriter) code(n *types.CodeNode) {
 	mw.newBlock()
 	defer mw.writeBytes(newLine)
-	if n.Term {
-		var buf bytes.Buffer
-		const prefix = "    "
-		lineStart := true
-		for _, r := range n.Value {
-			if lineStart {
-				buf.WriteString(prefix)
-			}
-			buf.WriteRune(r)
-			lineStart = r == '\n'
-		}
-		mw.writeBytes(buf.Bytes())
-		return
-	}
 	mw.writeString("```")
-	mw.writeString(n.Lang)
+	if n.Term {
+		mw.writeString("console")
+	} else {
+		mw.writeString(n.Lang)
+	}
 	mw.writeBytes(newLine)
 	mw.writeString(n.Value)
 	if !mw.lineStart {

--- a/claat/types/node.go
+++ b/claat/types/node.go
@@ -300,11 +300,12 @@ func (tn *TextNode) Empty() bool {
 
 // NewCodeNode creates a new Node of type NodeCode.
 // Use term argument to specify a terminal output.
-func NewCodeNode(v string, term bool) *CodeNode {
+func NewCodeNode(v string, term bool, lang string) *CodeNode {
 	return &CodeNode{
 		node:  node{typ: NodeCode},
 		Value: v,
 		Term:  term,
+		Lang: lang,
 	}
 }
 


### PR DESCRIPTION
Add support for language hint in code blocks aka:

```
```go
...
`` `
```

Add support for Console blocks (no syntax highlighting and no special Code block features in devsite). You can get these code blocks when using the consolas font in HTML or when using 

```
```console
...
`` `
```

This also fixes the issue where the console block formatting was lost in GDocs -> md exports (when using the consolas font).