### PR TITLE
Fix how whitespaces are trimmed before applying text styling

### DIFF
--- a/claat/render/md.go
+++ b/claat/render/md.go
@@ -42,12 +42,12 @@ func WriteMD(w io.Writer, env string, nodes ...types.Node) error {
 }
 
 type mdWriter struct {
-	w         io.Writer // output writer
-	env       string    // target environment
-	err       error     // error during any writeXxx methods
-	lineStart bool
-	isWritingTableCell bool // used to override lineStart for correct cell formatting
-	Prefix    string    // prefix for e.g. blockquote content
+	w                  io.Writer // output writer
+	env                string    // target environment
+	err                error     // error during any writeXxx methods
+	lineStart          bool
+	isWritingTableCell bool   // used to override lineStart for correct cell formatting
+	Prefix             string // prefix for e.g. blockquote content
 }
 
 func (mw *mdWriter) writeBytes(b []byte) {
@@ -130,42 +130,36 @@ func (mw *mdWriter) write(nodes ...types.Node) error {
 }
 
 func (mw *mdWriter) text(n *types.TextNode) {
-	t := strings.TrimSpace(n.Value)
-	tl := len([]rune(t))
-	nl := len([]rune(n.Value))
-	ls := nl - len([]rune(strings.TrimLeft(n.Value, " ")))
-	// Don't just copy above and TrimRight instead of TrimLeft to avoid " " counting as 1
-	// left space and 1 right space. Instead, number of right spaces is
-	// length of whole string - length of string with spaces trimmed - number of left spaces.
-	rs := nl - tl - ls
+	tr := strings.TrimLeft(n.Value, " \t\n\r\f\v")
+	left := n.Value[0:(len(n.Value) - len(tr))]
+	t := strings.TrimRight(tr, " \t\n\r\f\v")
+	right := tr[len(t):len(tr)]
 
-	mw.writeString(strings.Repeat(" ", ls))
-	if tl > 0 {
-		if n.Bold {
-			mw.writeString("**")
-		}
-		if n.Italic {
-			mw.writeString("*")
-		}
-		if n.Code {
-			mw.writeString("`")
-		}
+	mw.writeString(left)
+
+	if n.Bold {
+		mw.writeString("**")
+	}
+	if n.Italic {
+		mw.writeString("*")
+	}
+	if n.Code {
+		mw.writeString("`")
 	}
 
 	mw.writeString(t)
 
-	if tl > 0 {
-		if n.Code {
-			mw.writeString("`")
-		}
-		if n.Italic {
-			mw.writeString("*")
-		}
-		if n.Bold {
-			mw.writeString("**")
-		}
+	if n.Code {
+		mw.writeString("`")
 	}
-	mw.writeString(strings.Repeat(" ", rs))
+	if n.Italic {
+		mw.writeString("*")
+	}
+	if n.Bold {
+		mw.writeString("**")
+	}
+
+	mw.writeString(right)
 }
 
 func (mw *mdWriter) image(n *types.ImageNode) {
@@ -304,7 +298,7 @@ func (mw *mdWriter) table(n *types.GridNode) {
 			}
 
 			// Write cell separator
-			if(cellIndex != len(row) - 1){
+			if cellIndex != len(row)-1 {
 				mw.writeString(" | ")
 			} else {
 				mw.writeBytes(newLine)
@@ -312,10 +306,10 @@ func (mw *mdWriter) table(n *types.GridNode) {
 		}
 
 		// Write header bottom border
-		if(rowIndex == 0){
+		if rowIndex == 0 {
 			for index, _ := range row {
 				mw.writeString("---")
-				if(index != len(row) - 1){
+				if index != len(row)-1 {
 					mw.writeString(" | ")
 				}
 			}


### PR DESCRIPTION
This was causing, in some corner-cases, that we were loosing some line breaks/paragraphs in the GDocs -> Md flow like here:

![image](https://user-images.githubusercontent.com/3766663/93551850-35f29d80-f96f-11ea-87a5-e184a88c2dde.png)

Which should now be like this:

![image](https://user-images.githubusercontent.com/3766663/93551860-4145c900-f96f-11ea-8352-6d0c54eac32f.png)

Which reflects the Google docs and the behavior we have in the GDocs -> html flow