### PR TITLE
Fix alt text, titles in images

### DIFF
--- a/claat/parser/gdoc/parse.go
+++ b/claat/parser/gdoc/parse.go
@@ -622,7 +622,7 @@ func code(ds *docState, term bool) types.Node {
 	} else if ds.cur.Parent.FirstChild == ds.cur && ds.cur.Parent.DataAtom != atom.Span {
 		v = "\n" + v
 	}
-	var lang string;
+	var lang string
 	n := types.NewCodeNode(v, term, lang)
 	n.MutateBlock(td)
 	return n
@@ -669,11 +669,15 @@ func list(ds *docState) types.Node {
 // or an IframeNode if the alt property contains a URL other than youtube.
 func image(ds *docState) types.Node {
 	alt := nodeAttr(ds.cur, "alt")
+	// Consecutive newlines aren't supported in markdown images, and
+	// author-added double quotes in attributes break html syntax
+	alt = strings.Replace(alt, "\n", " ", -1)
+	alt = strings.Replace(alt, `"`, "&quot;", -1)
 	errorAlt := ""
 	if strings.Contains(alt, "youtube.com/watch") {
 		return youtube(ds)
 	} else if strings.Contains(alt, "https://") {
-		u, err := url.Parse(nodeAttr(ds.cur, "alt"))
+		u, err := url.Parse(alt)
 		if err != nil {
 			return nil
 		}
@@ -701,9 +705,10 @@ func image(ds *docState) types.Node {
 	if errorAlt != "" {
 		n.Alt = errorAlt
 	} else {
-		n.Alt = nodeAttr(ds.cur, "alt")
+		n.Alt = alt
 	}
-	n.Title = nodeAttr(ds.cur, "title")
+	// Author-added double quotes in attributes break html syntax
+	n.Title = strings.Replace(nodeAttr(ds.cur, "title"), `"`, "&quot;", -1)
 	return n
 }
 

--- a/claat/parser/md/parse.go
+++ b/claat/parser/md/parse.go
@@ -38,6 +38,7 @@ import (
 	"github.com/googlecodelabs/tools/claat/util"
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/extension"
+	gmhtml "github.com/yuin/goldmark/renderer/html"
 	"gopkg.in/russross/blackfriday.v2"
 )
 
@@ -248,7 +249,7 @@ func renderToHTML(b []byte, mdp parser.MarkdownParser) ([]byte, error) {
 
 		return blackfriday.Run(b, blackfriday.WithExtensions(extns), blackfriday.WithRenderer(r)), nil
 	case parser.Goldmark:
-		gmParser := goldmark.New(goldmark.WithExtensions(extension.Typographer, extension.Table))
+		gmParser := goldmark.New(goldmark.WithRendererOptions(gmhtml.WithUnsafe()), goldmark.WithExtensions(extension.Typographer, extension.Table))
 		var out bytes.Buffer
 		if err := gmParser.Convert(b, &out); err != nil {
 			panic(err)

--- a/claat/parser/md/parse.go
+++ b/claat/parser/md/parse.go
@@ -785,10 +785,12 @@ func list(ds *docState) types.Node {
 // It may also return a YouTubeNode if alt property contains specific substring.
 func image(ds *docState) types.Node {
 	alt := nodeAttr(ds.cur, "alt")
+	// Author-added double quotes in attributes break html syntax
+	alt = strings.Replace(alt, `"`, "&quot;", -1)
 	if strings.Contains(alt, "youtube.com/watch") {
 		return youtube(ds)
 	} else if strings.Contains(alt, "https://") {
-		u, err := url.Parse(nodeAttr(ds.cur, "alt"))
+		u, err := url.Parse(alt)
 		if err != nil {
 			return nil
 		}
@@ -811,12 +813,13 @@ func image(ds *docState) types.Node {
 
 	n := types.NewImageNode(s)
 
-	if alt := nodeAttr(ds.cur, "alt"); alt != "" {
+	if alt != "" {
 		n.Alt = alt
 	}
 
 	if title := nodeAttr(ds.cur, "title"); title != "" {
-		n.Title = title
+		// Author-added double quotes in attributes break html syntax
+		n.Title = strings.Replace(title, `"`, "&quot;", -1)
 	}
 
 	if ws := nodeAttr(ds.cur, "width"); ws != "" {

--- a/claat/render/md.go
+++ b/claat/render/md.go
@@ -165,16 +165,16 @@ func (mw *mdWriter) text(n *types.TextNode) {
 func (mw *mdWriter) image(n *types.ImageNode) {
 	mw.space()
 	mw.writeString("<img ")
-	mw.writeString(fmt.Sprintf("src=\"%s\" ", n.Src))
+	mw.writeString(fmt.Sprintf("src=%q ", n.Src))
 
 	if n.Alt != "" {
-		mw.writeString(fmt.Sprintf("alt=\"%s\" ", n.Alt))
+		mw.writeString(fmt.Sprintf("alt=%q ", n.Alt))
 	} else {
-		mw.writeString(fmt.Sprintf("alt=\"%s\" ", path.Base(n.Src)))
+		mw.writeString(fmt.Sprintf("alt=%q ", path.Base(n.Src)))
 	}
 
 	if n.Title != "" {
-		mw.writeString(fmt.Sprintf("title=\"%q\" ", n.Title))
+		mw.writeString(fmt.Sprintf("title=%q ", n.Title))
 	}
 
 	// If available append width to the src string of the image.


### PR DESCRIPTION
Previously, images with titles or containing newlines in alt text
would not render correctly

This commit
* removes newlines in alt text, which break markdown syntax (for
consecutive newlines) and don't parse correctly (for single newlines)
* removes duplicate double quotes applied to title attributes, which
break html syntax
* removes author-added double quotes in titles, which also break html
syntax, and replace with `&quot;`