### PR TITLE
Fix issue where styled spaces are preserved from a Google Doc.

### DIFF
--- a/claat/parser/gdoc/parse.go
+++ b/claat/parser/gdoc/parse.go
@@ -622,7 +622,7 @@ func code(ds *docState, term bool) types.Node {
 	} else if ds.cur.Parent.FirstChild == ds.cur && ds.cur.Parent.DataAtom != atom.Span {
 		v = "\n" + v
 	}
-	var lang string;
+	var lang string
 	n := types.NewCodeNode(v, term, lang)
 	n.MutateBlock(td)
 	return n
@@ -833,9 +833,12 @@ func text(ds *docState) types.Node {
 
 	v := stringifyNode(ds.cur, false, true)
 	n := types.NewTextNode(v)
-	n.Bold = bold
-	n.Italic = italic
-	n.Code = code
+	// Only apply styling if the node contains non-whitespace.
+	if len(strings.TrimSpace(v)) > 0 {
+		n.Bold = bold
+		n.Italic = italic
+		n.Code = code
+	}
 	n.MutateBlock(findBlockParent(ds.cur))
 	return n
 }


### PR DESCRIPTION
e.g. an italic space will no longer render as **