### PR TITLE
Complete survey support for markdown

### DIFF
--- a/claat/parser/md/parse.go
+++ b/claat/parser/md/parse.go
@@ -678,21 +678,28 @@ func tableRow(ds *docState) []*types.GridCell {
 	return row
 }
 
-// survey expects a name Node followed by 1 or more inputs Nodes. Each input node is expected to have a value attribute.
+// survey expects 1 or more name Nodes followed by 1 or more input Nodes.
+// Each input node is expected to have a value attribute.
 func survey(ds *docState) types.Node {
 	var gg []*types.SurveyGroup
-	hn := ds.cur
-	n := findAtom(hn, atom.Name)
-	inputs := findChildAtoms(hn, atom.Input)
-	opt := surveyOpt(inputs)
-
-	if len(opt) > 0 {
-		gg = append(gg, &types.SurveyGroup{
-			Name:    strings.TrimSpace(n.FirstChild.Data),
-			Options: opt,
-		})
+	ns := findChildAtoms(ds.cur, atom.Name)
+	for _, n := range ns {
+		var inputs []*html.Node
+		for hn := n.NextSibling; hn != nil; hn = hn.NextSibling {
+			if hn.DataAtom == atom.Input {
+				inputs = append(inputs, hn)
+			} else if hn.DataAtom == atom.Name {
+				break
+			}
+		}
+		opt := surveyOpt(inputs)
+		if len(opt) > 0 {
+			gg = append(gg, &types.SurveyGroup{
+				Name:    strings.TrimSpace(n.FirstChild.Data),
+				Options: opt,
+			})
+		}
 	}
-
 	if len(gg) == 0 {
 		return nil
 	}

--- a/claat/render/md.go
+++ b/claat/render/md.go
@@ -17,6 +17,7 @@ package render
 import (
 	"bytes"
 	"fmt"
+	htmlTemplate "html/template"
 	"io"
 	"path"
 	"sort"
@@ -63,6 +64,11 @@ func (mw *mdWriter) writeString(s string) {
 		s = mw.Prefix + s
 	}
 	mw.writeBytes([]byte(s))
+}
+
+func (mw *mdWriter) writeEscape(s string) {
+	s = htmlTemplate.HTMLEscapeString(s)
+	mw.writeString(ReplaceDoubleCurlyBracketsWithEntity(s))
 }
 
 func (mw *mdWriter) space() {
@@ -115,8 +121,8 @@ func (mw *mdWriter) write(nodes ...types.Node) error {
 			mw.table(n)
 		case *types.InfoboxNode:
 			mw.infobox(n)
-		//case *types.SurveyNode:
-		//	mw.survey(n)
+		case *types.SurveyNode:
+			mw.survey(n)
 		case *types.HeaderNode:
 			mw.header(n)
 		case *types.YouTubeNode:
@@ -270,6 +276,25 @@ func (mw *mdWriter) infobox(n *types.InfoboxNode) {
 	}
 
 	mw.Prefix = ""
+}
+
+func (mw *mdWriter) survey(n *types.SurveyNode) {
+	mw.newBlock()
+	mw.writeString("<form>")
+	mw.writeBytes(newLine)
+	for _, g := range n.Groups {
+		mw.writeString("<name>")
+		mw.writeEscape(g.Name)
+		mw.writeString("</name>")
+		mw.writeBytes(newLine)
+		for _, o := range g.Options {
+			mw.writeString("<input value=\"")
+			mw.writeEscape(o)
+			mw.writeString("\">")
+			mw.writeBytes(newLine)
+		}
+	}
+	mw.writeString("</form>")
 }
 
 func (mw *mdWriter) header(n *types.HeaderNode) {


### PR DESCRIPTION
Previously, surveys did not render from gdocs -> md (only from
md -> devsite). This commit implements the markdown renderer method
for surveys.

Additionally, this commit corrects parsing of markdown surveys, which
previously only parsed the first question in a survey.