### PR TITLE
Fix broken colspan.

### DIFF
--- a/claat/parser/md/parse.go
+++ b/claat/parser/md/parse.go
@@ -663,6 +663,15 @@ func tableRow(ds *docState) []*types.GridCell {
 		cs, err := strconv.Atoi(nodeAttr(td, "colspan"))
 		if err != nil {
 			cs = 1
+			for ns := td.NextSibling; ns != nil; ns = ns.NextSibling {
+				if ns.DataAtom != atom.Td && ns.DataAtom != atom.Th {
+					continue
+				}
+				if ns.FirstChild != nil {
+					break
+				}
+				cs += 1
+			}
 		}
 		rs, err := strconv.Atoi(nodeAttr(td, "rowspan"))
 		if err != nil {

--- a/claat/render/md.go
+++ b/claat/render/md.go
@@ -322,6 +322,7 @@ func (mw *mdWriter) youtube(n *types.YouTubeNode) {
 
 func (mw *mdWriter) table(n *types.GridNode) {
 	mw.writeBytes(newLine)
+	maxcols := maxColsInTable(n)
 	for rowIndex, row := range n.Rows {
 		mw.writeString("|")
 		for _, cell := range row {
@@ -333,12 +334,17 @@ func (mw *mdWriter) table(n *types.GridNode) {
 			}
 			mw.writeString(" |")
 		}
+		if rowIndex == 0 && len(row) < maxcols {
+			for i:= 0; i < maxcols - len(row); i++ {
+				mw.writeString(" |")
+			}
+		}
 		mw.writeBytes(newLine)
 
 		// Write header bottom border
 		if rowIndex == 0 {
 			mw.writeString("|")
-			for range row {
+			for i := 0; i < maxcols; i++ {
 				mw.writeString(" --- |")
 			}
 			mw.writeBytes(newLine)
@@ -346,4 +352,14 @@ func (mw *mdWriter) table(n *types.GridNode) {
 
 		mw.isWritingTableCell = false
 	}
+}
+
+func maxColsInTable(n *types.GridNode) int {
+	m := 0
+	for _, row := range n.Rows {
+		if len(row) > m {
+			m = len(row)
+		}
+	}
+	return m
 }


### PR DESCRIPTION
Two changes:

1) When parsing md, set colspan based on the number of empty siblings in a table.
2) When writing md from a gdoc, make the header and delimiter row match the max width (in columns) of the table.