### PR TITLE
Restrict HTML escaping in MD output to just <.

### DIFF
--- a/claat/render/md.go
+++ b/claat/render/md.go
@@ -154,7 +154,9 @@ func (mw *mdWriter) text(n *types.TextNode) {
 		mw.writeString("`")
 	}
 
-	mw.writeEscape(t)
+	t = strings.ReplaceAll(t, "<", "&lt;")
+
+	mw.writeString(t)
 
 	if n.Code {
 		mw.writeString("`")

--- a/claat/render/md.go
+++ b/claat/render/md.go
@@ -155,6 +155,7 @@ func (mw *mdWriter) text(n *types.TextNode) {
 	}
 
 	t = strings.ReplaceAll(t, "<", "&lt;")
+	t = strings.ReplaceAll(t, ">", "&gt;")
 
 	mw.writeString(t)
 

--- a/claat/render/md.go
+++ b/claat/render/md.go
@@ -154,8 +154,8 @@ func (mw *mdWriter) text(n *types.TextNode) {
 		mw.writeString("`")
 	}
 
-	t = strings.ReplaceAll(t, "<", "&lt;")
-	t = strings.ReplaceAll(t, ">", "&gt;")
+	t = strings.Replace(t, "<", "&lt;", -1)
+	t = strings.Replace(t, ">", "&gt;", -1)
 
 	mw.writeString(t)
 


### PR DESCRIPTION
Escaping ' has some undesirable consequences.