### PR TITLE
Compact content nodes of URL nodes

### DIFF
--- a/claat/parser/trim.go
+++ b/claat/parser/trim.go
@@ -151,6 +151,7 @@ func concatURL(a, b types.Node) bool {
 		return false
 	}
 	u1.Content.Append(u2.Content.Nodes...)
+	u1.Content.Nodes = CompactNodes(u1.Content.Nodes)
 	return true
 }
 


### PR DESCRIPTION
This prevents issues like what we saw with badly codified links, e.g.
```
[`codifi``ed link`](url)
```