### PR TITLE
Remove test command from Makefile.

### DIFF
--- a/claat/Makefile
+++ b/claat/Makefile
@@ -48,17 +48,13 @@ release: $(RELEASES)
 	echo $(VERSION) > $(OUTDIR)/VERSION
 	cd $(OUTDIR) && sha1sum claat* > sha1sum.txt
 
-test: .test
-.test: $(SRCS)
-	go test ./... && touch .test
-
 lint: .lint
 .lint: $(SRCS)
 	go vet ./...
 	golint ./... && touch .lint
 
 clean:
-	rm -rf $(OUTDIR) render/tmpldata.go .test .lint
+	rm -rf $(OUTDIR) render/tmpldata.go .lint
 
 $(OUTDIR)/claat-%: GOOS=$(firstword $(subst -, ,$*))
 $(OUTDIR)/claat-%: GOARCH=$(subst .exe,,$(word 2,$(subst -, ,$*)))


### PR DESCRIPTION
`go test` appears to cache its own results; this Makefile command was
not adding value.