### PR TITLE
Restructure `google_codelab` for readability.

### DIFF
--- a/codelab-elements/google-codelab/google_codelab.js
+++ b/codelab-elements/google-codelab/google_codelab.js
@@ -28,8 +28,8 @@ const events = goog.require('goog.events');
 const soy = goog.require('goog.soy');
 
 /**
- * Deprecated. Title causes the bowser to display a tooltip over the whole codelab.
- * Use codelab-title instead.
+ * Deprecated. Title causes the bowser to display a tooltip over the whole
+ * codelab. Use codelab-title instead.
  * @const {string}
  */
 const TITLE_ATTR = 'title';
@@ -123,7 +123,9 @@ const TAB_INDEX_ATTR = 'tabindex';
  */
 class Codelab extends HTMLElement {
   /** @return {string} */
-  static getTagName() { return 'google-codelab'; }
+  static getTagName() {
+    return 'google-codelab';
+  }
 
   constructor() {
     super();
@@ -180,9 +182,6 @@ class Codelab extends HTMLElement {
     this.transitionEventHandler_ = new EventHandler();
 
     /** @private {boolean} */
-    this.hasSetup_ = false;
-
-    /** @private {boolean} */
     this.ready_ = false;
 
     /** @private {?Transition} */
@@ -190,9 +189,6 @@ class Codelab extends HTMLElement {
 
     /** @private {?Transition} */
     this.transitionOut_ = null;
-
-    /** @private {boolean} */
-    this.resumed_ = false;
 
     /**
      * @private {!HTML5LocalStorage}
@@ -206,22 +202,10 @@ class Codelab extends HTMLElement {
    * @override
    */
   connectedCallback() {
-    if (!this.hasSetup_) {
-      this.setupDom_();
-    }
-
+    this.init_();
+    this.setupDom_();
     this.addEvents_();
-
-    this.configureAnalytics_();
-    this.showSelectedStep_();
-    this.updateTitle_();
-    this.toggleArrows_();
-    this.toggleToolbar_();
-
-    if (this.resumed_) {
-      console.log('resumed');
-      // TODO Show resume dialog
-    }
+    this.saveStep_();
 
     if (!this.ready_) {
       this.ready_ = true;
@@ -244,9 +228,11 @@ class Codelab extends HTMLElement {
    * @export
    */
   static get observedAttributes() {
-    return [TITLE_ATTR, CODELAB_TITLE_ATTR, ENVIRONMENT_ATTR, CATEGORY_ATTR,
-        FEEDBACK_LINK_ATTR, SELECTED_ATTR, LAST_UPDATED_ATTR, NO_TOOLBAR_ATTR,
-        NO_ARROWS_ATTR, ANALYTICS_READY_ATTR];
+    return [
+      TITLE_ATTR, CODELAB_TITLE_ATTR, ENVIRONMENT_ATTR, CATEGORY_ATTR,
+      FEEDBACK_LINK_ATTR, SELECTED_ATTR, LAST_UPDATED_ATTR, NO_TOOLBAR_ATTR,
+      NO_ARROWS_ATTR, ANALYTICS_READY_ATTR
+    ];
   }
 
   /**
@@ -272,6 +258,7 @@ class Codelab extends HTMLElement {
         break;
       case SELECTED_ATTR:
         this.showSelectedStep_();
+        this.saveStep_();
         break;
       case NO_TOOLBAR_ATTR:
         this.toggleToolbar_();
@@ -284,8 +271,8 @@ class Codelab extends HTMLElement {
           if (this.ready_) {
             this.firePageLoadEvents_();
           } else {
-            this.addEventListener(CODELAB_READY_EVENT,
-                () => this.firePageLoadEvents_());
+            this.addEventListener(
+                CODELAB_READY_EVENT, () => this.firePageLoadEvents_());
           }
         }
         break;
@@ -323,7 +310,7 @@ class Codelab extends HTMLElement {
       }
 
       analytics.setAttribute(
-        ENVIRONMENT_ATTR, this.getAttribute(ENVIRONMENT_ATTR));
+          ENVIRONMENT_ATTR, this.getAttribute(ENVIRONMENT_ATTR));
       analytics.setAttribute(CATEGORY_ATTR, this.getAttribute(CATEGORY_ATTR));
     }
   }
@@ -355,28 +342,30 @@ class Codelab extends HTMLElement {
    */
   addEvents_() {
     if (this.prevStepBtn_) {
-      this.eventHandler_.listen(this.prevStepBtn_, events.EventType.CLICK,
-        (e) => {
-          e.preventDefault();
-          e.stopPropagation();
-          this.selectPrevious();
-        });
+      this.eventHandler_.listen(
+          this.prevStepBtn_, events.EventType.CLICK, (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            this.selectPrevious();
+          });
     }
     if (this.nextStepBtn_) {
-      this.eventHandler_.listen(this.nextStepBtn_, events.EventType.CLICK,
-        (e) => {
-          e.preventDefault();
-          e.stopPropagation();
-          this.selectNext();
-        });
+      this.eventHandler_.listen(
+          this.nextStepBtn_, events.EventType.CLICK, (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            this.selectNext();
+          });
     }
 
     if (this.drawer_) {
-      this.eventHandler_.listen(this.drawer_, events.EventType.CLICK,
+      this.eventHandler_.listen(
+          this.drawer_, events.EventType.CLICK,
           (e) => this.handleDrawerClick_(e));
 
-      this.eventHandler_.listen(this.drawer_, events.EventType.KEYDOWN,
-            (e) => this.handleDrawerKeyDown_(e));
+      this.eventHandler_.listen(
+          this.drawer_, events.EventType.KEYDOWN,
+          (e) => this.handleDrawerKeyDown_(e));
     }
 
     if (this.titleContainer_) {
@@ -392,21 +381,30 @@ class Codelab extends HTMLElement {
           }
         });
 
-        this.eventHandler_.listen(document.body, events.EventType.CLICK, (e) => {
-          if (this.hasAttribute(DRAWER_OPEN_ATTR)) {
-            this.removeAttribute(DRAWER_OPEN_ATTR);
-          }
-        });
+        this.eventHandler_.listen(
+            document.body, events.EventType.CLICK, (e) => {
+              if (this.hasAttribute(DRAWER_OPEN_ATTR)) {
+                this.removeAttribute(DRAWER_OPEN_ATTR);
+              }
+            });
       }
     }
-
-    this.eventHandler_.listen(dom.getWindow(), events.EventType.POPSTATE, (e) => {
-      this.handlePopStateChanged_(e);
-    });
 
     this.eventHandler_.listen(document.body, events.EventType.KEYDOWN, (e) => {
       this.handleKeyDown_(e);
     });
+
+    // Start Google Feedback when the feedback link is clicked, if it exists.
+    const feedbackLink = this.querySelector('#codelab-feedback');
+    if (feedbackLink) {
+      this.eventHandler_.listen(feedbackLink, events.EventType.CLICK, (e) => {
+        if ('userfeedback' in window) {
+          window['userfeedback']['api']['startFeedback'](
+              {'productId': '5143948'});
+          e.preventDefault();
+        }
+      });
+    }
   }
 
   /**
@@ -500,20 +498,21 @@ class Codelab extends HTMLElement {
    * @private
    */
   handlePopStateChanged_(e) {
-    if (document.location.hash) {
+    const step = this.getStepFromHash_();
+    if (step) {
       this.setAttribute(DONT_SET_HISTORY_ATTR, '');
-      this.setAttribute(SELECTED_ATTR, document.location.hash.substring(1));
+      this.setAttribute(SELECTED_ATTR, `${step}`);
       this.removeAttribute(DONT_SET_HISTORY_ATTR);
     }
   }
 
-   /**
+  /**
    * Updates the browser history state
    * @param {string} path The new browser state
    * @param {boolean=} replaceState optionally replace state instead of pushing
    * @export
    */
-  updateHistoryState(path, replaceState=false) {
+  updateHistoryState(path, replaceState = false) {
     if (replaceState) {
       window.history.replaceState({path}, document.title, path);
     } else {
@@ -541,10 +540,8 @@ class Codelab extends HTMLElement {
       return;
     }
 
-    const selected = new URL(target.getAttribute('href'), document.location.origin)
-        .hash.substring(1);
-
-    this.setAttribute(SELECTED_ATTR, selected);
+    const step = this.getStepFromHash_();
+    this.setAttribute(SELECTED_ATTR, `${step}`);
   }
 
   /**
@@ -594,7 +591,7 @@ class Codelab extends HTMLElement {
       }
 
       // Update the time container with remaining time.
-      const newTimeEl =  soy.renderAsElement(Templates.timeRemaining, {time});
+      const newTimeEl = soy.renderAsElement(Templates.timeRemaining, {time});
       const oldTimeEl = timeContainer.querySelector('.time-remaining');
       if (oldTimeEl) {
         dom.replaceNode(newTimeEl, oldTimeEl);
@@ -623,18 +620,18 @@ class Codelab extends HTMLElement {
 
     let selected = 0;
     if (this.hasAttribute(SELECTED_ATTR)) {
-      selected = parseInt(this.getAttribute(SELECTED_ATTR), 0);
+      selected = parseInt(this.getAttribute(SELECTED_ATTR), 10);
     } else {
       this.setAttribute(SELECTED_ATTR, selected);
       return;
     }
 
-    selected = Math.min(Math.max(0, parseInt(selected, 10)),
-                        this.steps_.length - 1);
+    selected =
+        Math.min(Math.max(0, parseInt(selected, 10)), this.steps_.length - 1);
 
     if (this.currentSelectedStep_ === selected || isNaN(selected)) {
-      // Either the current step is already selected or an invalid option was provided
-      // do nothing and return.
+      // Either the current step is already selected or an invalid option was
+      // provided do nothing and return.
       return;
     }
 
@@ -663,13 +660,9 @@ class Codelab extends HTMLElement {
       this.transitionEventHandler_.removeAll();
 
       const transitionInInitialStyle = {};
-      const transitionInFinalStyle = {
-        transform: 'translate3d(0, 0, 0)'
-      };
+      const transitionInFinalStyle = {transform: 'translate3d(0, 0, 0)'};
 
-      const transitionOutInitialStyle = {
-        transform: 'translate3d(0, 0, 0)'
-      };
+      const transitionOutInitialStyle = {transform: 'translate3d(0, 0, 0)'};
       const transitionOutFinalStyle = {};
 
       const currentStep = this.steps_[this.currentSelectedStep_];
@@ -692,24 +685,28 @@ class Codelab extends HTMLElement {
         timing: 'cubic-bezier(0.4, 0, 0.2, 1)'
       }];
 
-      this.transitionIn_ = new Transition(stepToSelect, ANIMATION_DURATION,
-          transitionInInitialStyle, transitionInFinalStyle, animationProperties);
-      this.transitionOut_ = new Transition(currentStep, ANIMATION_DURATION,
-        transitionOutInitialStyle, transitionOutFinalStyle, animationProperties);
+      this.transitionIn_ = new Transition(
+          stepToSelect, ANIMATION_DURATION, transitionInInitialStyle,
+          transitionInFinalStyle, animationProperties);
+      this.transitionOut_ = new Transition(
+          currentStep, ANIMATION_DURATION, transitionOutInitialStyle,
+          transitionOutFinalStyle, animationProperties);
 
       this.transitionIn_.play();
       this.transitionOut_.play();
 
-      this.transitionEventHandler_.listenOnce(this.transitionIn_,
-            [TransitionEventType.FINISH, TransitionEventType.STOP], () => {
-        stepToSelect.setAttribute(SELECTED_ATTR, '');
-        stepToSelect.removeAttribute(ANIMATING_ATTR);
-      });
+      this.transitionEventHandler_.listenOnce(
+          this.transitionIn_,
+          [TransitionEventType.FINISH, TransitionEventType.STOP], () => {
+            stepToSelect.setAttribute(SELECTED_ATTR, '');
+            stepToSelect.removeAttribute(ANIMATING_ATTR);
+          });
 
-      this.transitionEventHandler_.listenOnce(this.transitionOut_,
-            [TransitionEventType.FINISH, TransitionEventType.STOP], () => {
-        currentStep.removeAttribute(SELECTED_ATTR);
-      });
+      this.transitionEventHandler_.listenOnce(
+          this.transitionOut_,
+          [TransitionEventType.FINISH, TransitionEventType.STOP], () => {
+            currentStep.removeAttribute(SELECTED_ATTR);
+          });
     }
 
     this.currentSelectedStep_ = selected;
@@ -762,14 +759,6 @@ class Codelab extends HTMLElement {
     }
 
     this.updateTimeRemaining_();
-    if (!this.hasAttribute(DONT_SET_HISTORY_ATTR)) {
-      this.updateHistoryState(`#${selected}`, true);
-    }
-
-    if (this.id_) {
-      this.storage_.set(`progress_${this.id_}`,
-                        String(this.currentSelectedStep_));
-    }
   }
 
   /**
@@ -808,7 +797,7 @@ class Codelab extends HTMLElement {
    * @param {!Object=} detail
    * @protected
    */
-  fireEvent_(eventName, detail={}) {
+  fireEvent_(eventName, detail = {}) {
     const event = new CustomEvent(eventName, {
       detail: detail,
       bubbles: true,
@@ -828,10 +817,8 @@ class Codelab extends HTMLElement {
 
     window.requestAnimationFrame(() => {
       document.body.removeAttribute('unresolved');
-      this.fireEvent_(CODELAB_ACTION_EVENT, {
-        'category': 'codelab',
-        'action': 'ready'
-      });
+      this.fireEvent_(
+          CODELAB_ACTION_EVENT, {'category': 'codelab', 'action': 'ready'});
     });
   }
 
@@ -854,43 +841,67 @@ class Codelab extends HTMLElement {
     this.prevStepBtn_ = this.querySelector('#controls #previous-step');
     this.nextStepBtn_ = this.querySelector('#controls #next-step');
     this.doneBtn_ = this.querySelector('#controls #done');
-
     this.steps_.forEach((step) => dom.appendChild(this.stepsContainer_, step));
     this.setupSteps_();
     this.renderDrawer_();
     this.timeContainer_ = this.querySelectorAll('.codelab-time-container');
+    this.configureAnalytics_();
+    this.showSelectedStep_();
+    this.updateTitle_();
+    this.toggleArrows_();
+    this.toggleToolbar_();
+  }
 
-    let hasLocationHash = false;
+  /**
+   * @private
+   * @return {number}
+   */
+  getStepFromHash_() {
     if (document.location.hash) {
-      const h = parseInt(document.location.hash.substring(1), 10);
-      if (!isNaN(h) && h) {
-        this.setAttribute(SELECTED_ATTR, document.location.hash.substring(1));
-        hasLocationHash = true;
+      const step = parseInt(document.location.hash.substring(1), 10);
+      if (!isNaN(step) && step) {
+        return step;
       }
     }
+    return 0;
+  }
 
+  /**
+   * @private
+   * @return {number}
+   */
+  getStepFromStorage_() {
+    const step = parseInt(this.storage_.get(`progress_${this.id_}`), 10);
+    if (!isNaN(step) && step) {
+      return step;
+    }
+    return 0;
+  }
+
+  /**
+   * @private
+   */
+  init_() {
     this.id_ = this.getAttribute(ID_ATTR);
-    const progress = this.storage_.get(`progress_${this.id_}`);
-    if (progress && progress !== '0') {
-      this.resumed_ = true;
-      if (!hasLocationHash) {
-        this.setAttribute(SELECTED_ATTR, progress);
-      }
-    }
-    // Start Google Feedback when the feedback link is clicked, if it exists.
-    const feedbackLink = this.querySelector('#codelab-feedback');
-    if (feedbackLink) {
-      this.eventHandler_.listen(feedbackLink, events.EventType.CLICK,
-        (e) => {
-          if ('userfeedback' in window) {
-            window['userfeedback']['api']['startFeedback']
-                ({'productId': '5143948'});
-            e.preventDefault();
-          }
+    let step = this.getStepFromHash_() || this.getStepFromStorage_();
+    this.setAttribute(SELECTED_ATTR, `${step}`);
+    this.eventHandler_.listen(
+        dom.getWindow(), events.EventType.POPSTATE, (e) => {
+          this.handlePopStateChanged_(e);
         });
-    }
+  }
 
-    this.hasSetup_ = true;
+  /**
+   * @private
+   */
+  saveStep_() {
+    if (this.id_) {
+      this.storage_.set(
+          `progress_${this.id_}`, String(this.currentSelectedStep_));
+    }
+    if (!this.hasAttribute(DONT_SET_HISTORY_ATTR)) {
+      this.updateHistoryState(`#${this.currentSelectedStep_}`, true);
+    }
   }
 }
 

--- a/codelab-elements/google-codelab/google_codelab.js
+++ b/codelab-elements/google-codelab/google_codelab.js
@@ -498,12 +498,10 @@ class Codelab extends HTMLElement {
    * @private
    */
   handlePopStateChanged_(e) {
-    const step = this.getStepFromHash_();
-    if (step) {
-      this.setAttribute(DONT_SET_HISTORY_ATTR, '');
-      this.setAttribute(SELECTED_ATTR, `${step}`);
-      this.removeAttribute(DONT_SET_HISTORY_ATTR);
-    }
+    const step = this.getStepFromHash_(document.location);
+    this.setAttribute(DONT_SET_HISTORY_ATTR, '');
+    this.setAttribute(SELECTED_ATTR, `${step}`);
+    this.removeAttribute(DONT_SET_HISTORY_ATTR);
   }
 
   /**
@@ -540,7 +538,7 @@ class Codelab extends HTMLElement {
       return;
     }
 
-    const step = this.getStepFromHash_();
+    const step = this.getStepFromHash_(new URL(target.getAttribute('href'), document.location.origin));
     this.setAttribute(SELECTED_ATTR, `${step}`);
   }
 
@@ -854,11 +852,12 @@ class Codelab extends HTMLElement {
 
   /**
    * @private
+   * @param {Url} url
    * @return {number}
    */
-  getStepFromHash_() {
-    if (document.location.hash) {
-      const step = parseInt(document.location.hash.substring(1), 10);
+  getStepFromHash_(url) {
+    if (url.hash) {
+      const step = parseInt(url.hash.substring(1), 10);
       if (!isNaN(step) && step) {
         return step;
       }
@@ -883,7 +882,7 @@ class Codelab extends HTMLElement {
    */
   init_() {
     this.id_ = this.getAttribute(ID_ATTR);
-    let step = this.getStepFromHash_() || this.getStepFromStorage_();
+    let step = this.getStepFromHash_(document.location) || this.getStepFromStorage_();
     this.setAttribute(SELECTED_ATTR, `${step}`);
     this.eventHandler_.listen(
         dom.getWindow(), events.EventType.POPSTATE, (e) => {
@@ -895,12 +894,12 @@ class Codelab extends HTMLElement {
    * @private
    */
   saveStep_() {
+    if (!this.hasAttribute(DONT_SET_HISTORY_ATTR)) {
+      this.updateHistoryState(`#${this.currentSelectedStep_}`, true);
+    }
     if (this.id_) {
       this.storage_.set(
           `progress_${this.id_}`, String(this.currentSelectedStep_));
-    }
-    if (!this.hasAttribute(DONT_SET_HISTORY_ATTR)) {
-      this.updateHistoryState(`#${this.currentSelectedStep_}`, true);
     }
   }
 }

--- a/codelab-elements/google-codelab/google_codelab.js
+++ b/codelab-elements/google-codelab/google_codelab.js
@@ -498,7 +498,7 @@ class Codelab extends HTMLElement {
    * @private
    */
   handlePopStateChanged_(e) {
-    const step = this.getStepFromHash_(document.location);
+    const step = this.getStepFromHash_(document.location.hash);
     this.setAttribute(DONT_SET_HISTORY_ATTR, '');
     this.setAttribute(SELECTED_ATTR, `${step}`);
     this.removeAttribute(DONT_SET_HISTORY_ATTR);
@@ -538,7 +538,9 @@ class Codelab extends HTMLElement {
       return;
     }
 
-    const step = this.getStepFromHash_(new URL(target.getAttribute('href'), document.location.origin));
+    const hash =
+        new URL(target.getAttribute('href'), document.location.origin).hash;
+    const step = this.getStepFromHash_(hash);
     this.setAttribute(SELECTED_ATTR, `${step}`);
   }
 
@@ -852,12 +854,12 @@ class Codelab extends HTMLElement {
 
   /**
    * @private
-   * @param {Url} url
+   * @param {string} hash
    * @return {number}
    */
-  getStepFromHash_(url) {
-    if (url.hash) {
-      const step = parseInt(url.hash.substring(1), 10);
+  getStepFromHash_(hash) {
+    if (hash) {
+      const step = parseInt(hash.substring(1), 10);
       if (!isNaN(step) && step) {
         return step;
       }
@@ -882,7 +884,8 @@ class Codelab extends HTMLElement {
    */
   init_() {
     this.id_ = this.getAttribute(ID_ATTR);
-    let step = this.getStepFromHash_(document.location) || this.getStepFromStorage_();
+    let step = this.getStepFromHash_(document.location.hash) ||
+        this.getStepFromStorage_();
     this.setAttribute(SELECTED_ATTR, `${step}`);
     this.eventHandler_.listen(
         dom.getWindow(), events.EventType.POPSTATE, (e) => {


### PR DESCRIPTION
* Reformat
* Remove `hasSetup_`
* Remove `resumed_`
* Create `getStepFromHash_`
* Create `getStepFromStorage_`
* Create `init_`
* Create `saveStep_`
* Move DOM setup logic to `setupDom_`
  * `configureAnalytics_()`
  * `showSelectedStep_()`
  * `updateTitle_()`
  * `toggleArrows_()`
  * `toggleToolbar_()`
* Move feedback link event setup to `addEvents_`
* Extract `saveStep_` from `showSelectedStep_`
* Move `POPSTATE` event setup to `init_`