### PR TITLE
Remove non-existing selector ::content

### DIFF
--- a/codelab-elements/google-codelab-step/google_codelab_step.scss
+++ b/codelab-elements/google-codelab-step/google_codelab_step.scss
@@ -174,8 +174,7 @@ google-codelab-step .instructions ul.checklist {
   padding: 0 0 0 1em;
 }
 
-google-codelab-step .instructions ul.checklist li,
-google-codelab-step .instructions ::content ul.checklist li {
+google-codelab-step .instructions ul.checklist li {
   padding-left: 24px;
   background-size: 20px;
   background-repeat: no-repeat;


### PR DESCRIPTION
https://www.w3.org/TR/css-pseudo-4/ claims that this selector doesn't exist. This malformed rule causes the entire block to be skipped, which breaks the checklist list item markers in e.g. "What you'll learn" in https://codelabs.developers.google.com/codelabs/arcore-cloud-anchors#0.