### PR TITLE
Snake case metadata table field names

### DIFF
--- a/claat/parser/gdoc/parse.go
+++ b/claat/parser/gdoc/parse.go
@@ -27,11 +27,12 @@ import (
 
 	"golang.org/x/net/html"
 	"golang.org/x/net/html/atom"
-
+	
 	"github.com/googlecodelabs/tools/claat/nodes"
 	"github.com/googlecodelabs/tools/claat/parser"
 	"github.com/googlecodelabs/tools/claat/types"
 	"github.com/googlecodelabs/tools/claat/util"
+        "github.com/stoewer/go-strcase"
 )
 
 func init() {
@@ -390,7 +391,7 @@ func metaTable(ds *docState) {
 			continue
 		}
 		s := stringifyNode(tr.FirstChild.NextSibling, true, false)
-		fieldName := strings.ToLower(stringifyNode(tr.FirstChild, true, false))
+		fieldName := strcase.SnakeCase(stringifyNode(tr.FirstChild, true, false))
 		switch fieldName {
 		case "id", "url":
 			ds.clab.ID = s
@@ -407,9 +408,9 @@ func metaTable(ds *docState) {
 			v := util.NormalizedSplit(s)
 			sv := types.LegacyStatus(v)
 			ds.clab.Status = &sv
-		case "feedback", "feedback link":
+		case "feedback", "feedback_link":
 			ds.clab.Feedback = s
-		case "analytics", "analytics account", "google analytics":
+		case "analytics", "analytics_account", "google_analytics":
 			ds.clab.GA = s
 		default:
 			// If not explicitly parsed, it might be a pass_metadata value.

--- a/claat/parser/gdoc/parse.go
+++ b/claat/parser/gdoc/parse.go
@@ -27,7 +27,7 @@ import (
 
 	"golang.org/x/net/html"
 	"golang.org/x/net/html/atom"
-	
+
 	"github.com/googlecodelabs/tools/claat/nodes"
 	"github.com/googlecodelabs/tools/claat/parser"
 	"github.com/googlecodelabs/tools/claat/types"

--- a/claat/parser/gdoc/parse_test.go
+++ b/claat/parser/gdoc/parse_test.go
@@ -214,7 +214,7 @@ func TestMetaTablePassMetadata(t *testing.T) {
 				<td>Final</td>
 			</tr>
 			<tr>
-				<td>Feedback</td>
+				<td>Feedback Link</td>
 				<td>https://example.com/issues</td>
 			</tr>
 			<tr>
@@ -237,7 +237,7 @@ func TestMetaTablePassMetadata(t *testing.T) {
 	p := &Parser{}
 	opts := *parser.NewOptions()
 	opts.PassMetadata = map[string]bool{
-		"extrafieldone": true,
+		"extra_field_one": true,
 	}
 
 	clab, err := p.Parse(markupReader(markup), opts)
@@ -256,7 +256,7 @@ func TestMetaTablePassMetadata(t *testing.T) {
 		// TODO: move sorting to Parse of the parser package
 		Tags: []string{"kiosk", "web"},
 		Extra: map[string]string{
-			"extrafieldone": "11111",
+			"extra_field_one": "11111",
 		},
 	}
 	if !reflect.DeepEqual(clab.Meta, meta) {

--- a/claat/parser/md/parse.go
+++ b/claat/parser/md/parse.go
@@ -32,7 +32,7 @@ import (
 
 	"golang.org/x/net/html"
 	"golang.org/x/net/html/atom"
-	"google3/third_party/golang/strcase/strcase"
+	"github.com/stoewer/go-strcase"
 
 	"github.com/googlecodelabs/tools/claat/nodes"
 	"github.com/googlecodelabs/tools/claat/parser"

--- a/claat/parser/md/parse.go
+++ b/claat/parser/md/parse.go
@@ -32,6 +32,7 @@ import (
 
 	"golang.org/x/net/html"
 	"golang.org/x/net/html/atom"
+	"google3/third_party/golang/strcase/strcase"
 
 	"github.com/googlecodelabs/tools/claat/nodes"
 	"github.com/googlecodelabs/tools/claat/parser"
@@ -50,8 +51,8 @@ const (
 	MetaCategories       = "categories"
 	MetaEnvironments     = "environments"
 	MetaStatus           = "status"
-	MetaFeedbackLink     = "feedback link"
-	MetaAnalyticsAccount = "analytics account"
+	MetaFeedbackLink     = "feedback_link"
+	MetaAnalyticsAccount = "analytics_account"
 	MetaTags             = "tags"
 	MetaSource           = "source"
 	MetaDuration         = "duration"
@@ -411,7 +412,7 @@ func parseMetadata(ds *docState, opts parser.Options) error {
 // and assigns the values to any keys that match a codelab metadata field as defined by the meta* constants.
 func addMetadataToCodelab(m map[string]string, c *types.Codelab, opts parser.Options) error {
 	for k, v := range m {
-		switch k {
+		switch strcase.SnakeCase(k) {
 		case MetaAuthors:
 			// Directly assign the summary to the codelab field.
 			c.Authors = v

--- a/claat/parser/md/parse_test.go
+++ b/claat/parser/md/parse_test.go
@@ -205,7 +205,7 @@ func TestParseMetadataPassMetadata(t *testing.T) {
 		Feedback:   "https://www.google.com",
 		GA:         "12345",
 		Extra: map[string]string{
-			"extrafieldtwo": "bbbbb",
+			"extra_field_two": "bbbbb",
 		},
 	}
 
@@ -217,8 +217,8 @@ categories: not, really
 environments: kiosk, web
 analytics account: 12345
 feedback link: https://www.google.com
-extrafieldone: aaaaa
-extrafieldtwo: bbbbb
+extra_field_one: aaaaa
+extra_field_two: bbbbb
 
 ---
 `

--- a/claat/parser/md/parse_test.go
+++ b/claat/parser/md/parse_test.go
@@ -226,7 +226,7 @@ extra_field_two: bbbbb
 
 	opts := *parser.NewOptions()
 	opts.PassMetadata = map[string]bool{
-		"extrafieldtwo": true,
+		"extra_field_two": true,
 	}
 
 	c := mustParseCodelab(content, opts)

--- a/claat/parser/md/parse_test.go
+++ b/claat/parser/md/parse_test.go
@@ -180,8 +180,8 @@ authors: john smith
 summary: abcdefghij
 categories: not, really
 environments: kiosk, web
-analytics account: 12345
-feedback link: https://www.google.com
+analytics_account: 12345
+feedback_link: https://www.google.com
 
 ---
 `
@@ -215,8 +215,8 @@ authors: john smith
 summary: abcdefghij
 categories: not, really
 environments: kiosk, web
-analytics account: 12345
-feedback link: https://www.google.com
+analytics_account: 12345
+feedback_link: https://www.google.com
 extra_field_one: aaaaa
 extra_field_two: bbbbb
 
@@ -277,8 +277,8 @@ authors: john smith
 summary: abcdefghij
 categories: not, really
 environments: kiosk, web
-analytics account: 12345
-feedback link: https://www.google.com
+analytics_account: 12345
+feedback_link: https://www.google.com
 extrafieldone: aaaaa
 extrafieldtwo: bbbbb
 


### PR DESCRIPTION
Snake case metadata table field names.
* This improves author experience by accepting more variants of metadata field names
* This changes generated MarkDown codelabs to output `snake_case` metadata field names
* This also improves the readability and handling of keys in metadata Extras.
