### PR TITLE
Fix infoboxes in markdown on main

### DIFF
--- a/claat/parser/md/parse.go
+++ b/claat/parser/md/parse.go
@@ -232,7 +232,7 @@ func (ds *docState) appendNodes(nn ...nodes.Node) {
 // It takes a raw markdown bytes and outputs parsed xhtml in bytes.
 func renderToHTML(b []byte) ([]byte, error) {
 	b = convertImports(b)
-	gmParser := goldmark.New(goldmark.WithRendererOptions(gmhtml.WithUnsafe()), goldmark.WithExtensions(extension.Typographer, extension.Table))
+	gmParser := goldmark.New(goldmark.WithRendererOptions(gmhtml.WithUnsafe()), goldmark.WithExtensions(extension.Typographer, extension.Table, extension.DefinitionList, extension.Strikethrough))
 	var out bytes.Buffer
 	if err := gmParser.Convert(b, &out); err != nil {
 		panic(err)


### PR DESCRIPTION
The suggested format is
```
Positive
: Foo
```

which is actually a definition list in markdown. That's an extension in goldmark that's not currently enabled.

Also added `Strikethrough` while I'm here. There's also a `Linkify` extension that I wasn't sure about, but worth considering.