### PR TITLE
Path env install step

### DIFF
--- a/claat/README.md
+++ b/claat/README.md
@@ -16,13 +16,11 @@ Alternatively, if you have [Go installed](https://golang.org/doc/install) comple
 
 1. Ensure that go is included in your PATH env variable by adding the following line either to your .bashrc, .profile, or .zshrc file depending on what your shell is:
 ```
-    export PATH=$PATH:$HOME/go/bin/
+export PATH=$PATH:$HOME/go/bin/
 ```
-
 2. Run the following command
-
 ```
-    go install github.com/googlecodelabs/tools/claat@latest
+go install github.com/googlecodelabs/tools/claat@latest
 ``` 
   
 If none of the above works, compile the tool from source following Dev workflow


### PR DESCRIPTION
This is a simple change to the installation instructions, adding in the step of adding go to one's path environment to ensure that a newcomer to Go will have no issues setting up CLAAT. Please let me know if there are any further changes I should make. Thanks!