### PR TITLE
Add demo.arcade.software to the whitelist

### DIFF
--- a/claat/nodes/iframe.go
+++ b/claat/nodes/iframe.go
@@ -7,6 +7,7 @@ var IframeAllowlist = []string{
 	"codepen.io",
 	"dartlang.org",
 	"dartpad.dev",
+	"demo.arcade.software",
 	"github.com",
 	"glitch.com",
 	"google.com",


### PR DESCRIPTION
Just adding demo.arcade.software to the iframe whitelist. [Arcades](https://arcade.software) are interactive guides that can be embedded into documentation sites. Helpful for instructing users how to do something inside a product. I've signed the CLA.